### PR TITLE
Add BeagleBone AI P8 & P9 header pinmux nodes

### DIFF
--- a/src/arm/am5729-beagleboneai.dts
+++ b/src/arm/am5729-beagleboneai.dts
@@ -268,6 +268,704 @@
 };
 
 &dra7_pmx_core {
+    /************************/
+	/* P8 Header */
+	/************************/
+
+	/* P8_01                GND */
+
+	/* P8_02                GND */
+
+
+	/* P8_03 */
+	P8_03_default_pin: pinmux_P8_03_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x379C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_03_gpio_pin: pinmux_P8_03_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x379C, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_03_gpio_pu_pin: pinmux_P8_03_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x379C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_03_gpio_pd_pin: pinmux_P8_03_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x379C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_03_gpio_input_pin: pinmux_P8_03_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x379C, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_04 */
+	P8_04_default_pin: pinmux_P8_04_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x37A0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_04_gpio_pin: pinmux_P8_04_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x37A0, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_04_gpio_pu_pin: pinmux_P8_04_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x37A0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_04_gpio_pd_pin: pinmux_P8_04_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x37A0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_04_gpio_input_pin: pinmux_P8_04_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x37A0, PIN_INPUT | MUX_MODE14) >; };			
+
+	/* P8_05 */
+	P8_05_default_pin: pinmux_P8_05_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x378C PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_05_gpio_pin: pinmux_P8_05_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x378C PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_05_gpio_pu_pin: pinmux_P8_05_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x378C PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_05_gpio_pd_pin: pinmux_P8_05_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x378C PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_05_gpio_input_pin: pinmux_P8_05_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x378C PIN_INPUT | MUX_MODE14) >; };			
+
+	/* P8_06 */
+	P8_06_default_pin: pinmux_P8_06_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3790, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_06_gpio_pin: pinmux_P8_06_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3790, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_06_gpio_pu_pin: pinmux_P8_06_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3790, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_06_gpio_pd_pin: pinmux_P8_06_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3790, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_06_gpio_input_pin: pinmux_P8_06_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3790, PIN_INPUT | MUX_MODE14) >; };			
+
+	/* P8_07 */
+	P8_07_default_pin: pinmux_P8_07_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_07_gpio_pin: pinmux_P8_07_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_07_gpio_pu_pin: pinmux_P8_07_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_07_gpio_pd_pin: pinmux_P8_07_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_07_gpio_input_pin: pinmux_P8_07_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_INPUT | MUX_MODE14) >; };			
+	P8_07_timer_pin: pinmux_P8_07_timer_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36EC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_08 */
+	P8_08_default_pin: pinmux_P8_08_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_08_gpio_pin: pinmux_P8_08_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_08_gpio_pu_pin: pinmux_P8_08_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_08_gpio_pd_pin: pinmux_P8_08_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_08_gpio_input_pin: pinmux_P8_08_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_INPUT | MUX_MODE14) >; };			
+	P8_08_timer_pin: pinmux_P8_08_timer_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36F0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_09 */
+	P8_09_default_pin: pinmux_P8_09_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_09_gpio_pin: pinmux_P8_09_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_09_gpio_pu_pin: pinmux_P8_09_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_09_gpio_pd_pin: pinmux_P8_09_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_09_gpio_input_pin: pinmux_P8_09_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_INPUT | MUX_MODE14) >; };			
+	P8_09_timer_pin: pinmux_P8_09_timer_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3698, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_10 */
+	P8_10_default_pin: pinmux_P8_10_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_10_gpio_pin: pinmux_P8_10_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_10_gpio_pu_pin: pinmux_P8_10_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_10_gpio_pd_pin: pinmux_P8_10_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_10_gpio_input_pin: pinmux_P8_10_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_INPUT | MUX_MODE14) >; };			
+	P8_10_timer_pin: pinmux_P8_10_timer_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x36E8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_11 */
+	P8_11_default_pin: pinmux_P8_11_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_11_gpio_pin: pinmux_P8_11_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_11_gpio_pu_pin: pinmux_P8_11_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_11_gpio_pd_pin: pinmux_P8_11_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_11_gpio_input_pin: pinmux_P8_11_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_INPUT | MUX_MODE14) >; };			
+	P8_11_qep_pin: pinmux_P8_11_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+	P8_11_pruout_pin: pinmux_P8_11_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3510, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+
+	/* P8_12 */
+	P8_12_default_pin: pinmux_P8_12_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_12_gpio_pin: pinmux_P8_12_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_12_gpio_pu_pin: pinmux_P8_12_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_12_gpio_pd_pin: pinmux_P8_12_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_12_gpio_input_pin: pinmux_P8_12_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_INPUT | MUX_MODE14) >; };			
+	P8_12_qep_pin: pinmux_P8_12_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+	P8_12_pruout_pin: pinmux_P8_12_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x350C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+
+	/* P8_13 */
+	P8_13_default_pin: pinmux_P8_13_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_13_gpio_pin: pinmux_P8_13_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_13_gpio_pu_pin: pinmux_P8_13_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_13_gpio_pd_pin: pinmux_P8_13_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_13_gpio_input_pin: pinmux_P8_13_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_INPUT | MUX_MODE14) >; };			
+	P8_13_pwm_pin: pinmux_P8_13_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3590, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE10) >; };
+
+	/* P8_14 */
+	P8_14_default_pin: pinmux_P8_14_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_14_gpio_pin: pinmux_P8_14_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_14_gpio_pu_pin: pinmux_P8_14_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_14_gpio_pd_pin: pinmux_P8_14_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_14_gpio_input_pin: pinmux_P8_14_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_INPUT | MUX_MODE14) >; };			
+	P8_14_pwm_pin: pinmux_P8_14_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3598, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_15a */
+	P8_15_default_pin: pinmux_P8_15_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_15_gpio_pin: pinmux_P8_15_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_15_gpio_pu_pin: pinmux_P8_15_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_15_gpio_pd_pin: pinmux_P8_15_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_15_gpio_input_pin: pinmux_P8_15_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_INPUT | MUX_MODE14) >; };			
+	P8_15_qep_pin: pinmux_P8_15_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2_strobe available on P8.18*/
+	P8_15_pru_ecap_pin: pinmux_P8_15_pru_ecap_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3570, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE11) >; };	
+	
+	/* P8_15b */
+	P8_15_pruin_pin: pinmux_P8_15_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B4, PIN_INPUT | MUX_MODE12) >; };	
+
+	/* P8_16 */
+	P8_16_default_pin: pinmux_P8_16_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_16_gpio_pin: pinmux_P8_16_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_16_gpio_pu_pin: pinmux_P8_16_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_16_gpio_pd_pin: pinmux_P8_16_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_16_gpio_input_pin: pinmux_P8_16_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_INPUT | MUX_MODE14) >; };			
+	P8_16_qep_pin: pinmux_P8_16_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2_index available on P8.15*/
+	P8_16_pruin_pin: pinmux_P8_16_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35BC, PIN_INPUT | MUX_MODE12) >; };			
+		
+	/* P8_17 */
+	P8_17_default_pin: pinmux_P8_17_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_17_gpio_pin: pinmux_P8_17_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_17_gpio_pu_pin: pinmux_P8_17_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_17_gpio_pd_pin: pinmux_P8_17_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_17_gpio_input_pin: pinmux_P8_17_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_INPUT | MUX_MODE14) >; };			
+	P8_17_pwm_pin: pinmux_P8_17_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3624, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm0_synco */
+	
+	/* P8_18 */
+	P8_18_default_pin: pinmux_P8_18_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3588, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_18_gpio_pin: pinmux_P8_18_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3588, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_18_gpio_pu_pin: pinmux_P8_18_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3588, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_18_gpio_pd_pin: pinmux_P8_18_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3588, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_18_gpio_input_pin: pinmux_P8_18_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3588, PIN_INPUT | MUX_MODE14) >; };	
+
+	/* P8_19 */
+	P8_19_default_pin: pinmux_P8_19_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_19_gpio_pin: pinmux_P8_19_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_19_gpio_pu_pin: pinmux_P8_19_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_19_gpio_pd_pin: pinmux_P8_19_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_19_gpio_input_pin: pinmux_P8_19_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_INPUT | MUX_MODE14) >; };			
+	P8_19_pwm_pin: pinmux_P8_19_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x358C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE10) >; };
+		
+	/* P8_20 (ZCZ ball V9) emmc */
+	P8_20_default_pin: pinmux_P8_20_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_20_gpio_pin: pinmux_P8_20_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_20_gpio_pu_pin: pinmux_P8_20_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_20_gpio_pd_pin: pinmux_P8_20_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_20_gpio_input_pin: pinmux_P8_20_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_INPUT | MUX_MODE14) >; };			
+	P8_20_pruout_pin: pinmux_P8_20_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_20_pruin_pin: pinmux_P8_20_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3780, PIN_INPUT | MUX_MODE12) >; };		
+
+	/* P8_21 */
+	P8_21_default_pin: pinmux_P8_21_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_21_gpio_pin: pinmux_P8_21_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_21_gpio_pu_pin: pinmux_P8_21_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_21_gpio_pd_pin: pinmux_P8_21_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_21_gpio_input_pin: pinmux_P8_21_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_INPUT | MUX_MODE14) >; };			
+	P8_21_pruout_pin: pinmux_P8_21_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_21_pruin_pin: pinmux_P8_21_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x377C, PIN_INPUT | MUX_MODE12) >; };			
+
+	/* P8_22 */
+	P8_22_default_pin: pinmux_P8_22_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3798, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };
+	P8_22_gpio_pin: pinmux_P8_22_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3798, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };	
+	P8_22_gpio_pu_pin: pinmux_P8_22_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3798, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };
+	P8_22_gpio_pd_pin: pinmux_P8_22_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3798, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };
+	P8_22_gpio_input_pin: pinmux_P8_22_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3798, PIN_INPUT | MUX_MODE14) >; };		
+
+	/* P8_23 */
+	P8_23_default_pin: pinmux_P8_23_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3794, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_23_gpio_pin: pinmux_P8_23_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3794, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_23_gpio_pu_pin: pinmux_P8_23_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3794, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_23_gpio_pd_pin: pinmux_P8_23_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3794, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_23_gpio_input_pin: pinmux_P8_23_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3794, PIN_INPUT | MUX_MODE14) >; };			
+
+	/* P8_24 */
+	P8_24_default_pin: pinmux_P8_24_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3788, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_24_gpio_pin: pinmux_P8_24_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3788, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_24_gpio_pu_pin: pinmux_P8_24_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3788, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_24_gpio_pd_pin: pinmux_P8_24_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3788, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_24_gpio_input_pin: pinmux_P8_24_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3788, PIN_INPUT | MUX_MODE14) >; };			
+
+	/* P8_25 */
+	P8_25_default_pin: pinmux_P8_25_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3784, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_25_gpio_pin: pinmux_P8_25_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3784, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_25_gpio_pu_pin: pinmux_P8_25_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3784, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_25_gpio_pd_pin: pinmux_P8_25_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3784, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_25_gpio_input_pin: pinmux_P8_25_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3784, PIN_INPUT | MUX_MODE14) >; };	
+
+	/* P8_26 */
+	P8_26_default_pin: pinmux_P8_26_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_26_gpio_pin: pinmux_P8_26_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_26_gpio_pu_pin: pinmux_P8_26_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_26_gpio_pd_pin: pinmux_P8_26_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_26_gpio_input_pin: pinmux_P8_26_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35B8, PIN_INPUT | MUX_MODE14) >; };	
+
+	/* P8_27a */
+	P8_27_default_pin: pinmux_P8_27_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_27_gpio_pin: pinmux_P8_27_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_27_gpio_pu_pin: pinmux_P8_27_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_27_gpio_pd_pin: pinmux_P8_27_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_27_gpio_input_pin: pinmux_P8_27_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D8, PIN_INPUT | MUX_MODE14) >; };	
+
+	/* P8_27b */		
+	P8_27_pruout_pin: pinmux_P8_27_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3628, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_27_pruin_pin: pinmux_P8_27_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3628, PIN_INPUT | MUX_MODE12) >; };			
+		
+	/* P8_28a */
+	P8_28_default_pin: pinmux_P8_28_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35C8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_28_gpio_pin: pinmux_P8_28_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35C8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_28_gpio_pu_pin: pinmux_P8_28_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35C8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_28_gpio_pd_pin: pinmux_P8_28_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35C8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_28_gpio_input_pin: pinmux_P8_28_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35C8, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_28b */
+	P8_28_pruout_pin: pinmux_P8_28_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x362C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_28_pruin_pin: pinmux_P8_28_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x362C, PIN_INPUT | MUX_MODE12) >; };			
+
+	/* P8_29a */
+	P8_29_default_pin: pinmux_P8_29_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_29_gpio_pin: pinmux_P8_29_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D4, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_29_gpio_pu_pin: pinmux_P8_29_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_29_gpio_pd_pin: pinmux_P8_29_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_29_gpio_input_pin: pinmux_P8_29_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35D4, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_29b */
+	P8_29_pruout_pin: pinmux_P8_29_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3630, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_29_pruin_pin: pinmux_P8_29_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3630, PIN_INPUT | MUX_MODE12) >; };			
+
+	/* P8_30a */
+	P8_30_default_pin: pinmux_P8_30_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35CC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_30_gpio_pin: pinmux_P8_30_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35CC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_30_gpio_pu_pin: pinmux_P8_30_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35CC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_30_gpio_pd_pin: pinmux_P8_30_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35CC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_30_gpio_input_pin: pinmux_P8_30_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35CC, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_30b */
+	P8_30_pruout_pin: pinmux_P8_30_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3634, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_30_pruin_pin: pinmux_P8_30_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3634, PIN_INPUT | MUX_MODE12) >; };			
+
+
+	/* P8_31a */
+	P8_31_default_pin: pinmux_P8_31_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3614, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_31_gpio_pin: pinmux_P8_31_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3614, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_31_gpio_pu_pin: pinmux_P8_31_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3614, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_31_gpio_pd_pin: pinmux_P8_31_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3614, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_31_gpio_input_pin: pinmux_P8_31_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3614, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_31b */
+	P8_31_qep_pin: pinmux_P8_31_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x373C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep1_index */
+	P8_31_uart_pin: pinmux_P8_31_uart_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x373C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };
+
+	/* P8_32a */
+	P8_32_default_pin: pinmux_P8_32_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3618, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_32_gpio_pin: pinmux_P8_32_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3618, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_32_gpio_pu_pin: pinmux_P8_32_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3618, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_32_gpio_pd_pin: pinmux_P8_32_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3618, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_32_gpio_input_pin: pinmux_P8_32_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3618, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_32b */
+	P8_32_qep_pin: pinmux_P8_32_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3740, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2) >; };	/* ?? eqep1_strobe available on P9_21*/
+
+	/* P8_33a */
+	P8_33_default_pin: pinmux_P8_33_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3610, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_33_gpio_pin: pinmux_P8_33_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3610, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_33_gpio_pu_pin: pinmux_P8_33_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3610, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_33_gpio_pd_pin: pinmux_P8_33_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3610, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_33_gpio_input_pin: pinmux_P8_33_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3610, PIN_INPUT | MUX_MODE14) >; };
+
+	/* P8_33b */			
+	P8_33_qep_pin: pinmux_P8_33_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x34E8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	
+	/* P8_34a */
+	P8_34_default_pin: pinmux_P8_34_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3608, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_34_gpio_pin: pinmux_P8_34_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3608, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_34_gpio_pu_pin: pinmux_P8_34_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3608, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_34_gpio_pd_pin: pinmux_P8_34_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3608, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_34_gpio_input_pin: pinmux_P8_34_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3608, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_34b */
+	P8_34_pwm_pin: pinmux_P8_34_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3564, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE10) >; };	/* ?? ehrpwm1b instead we have ehrpwm1a here */
+
+	/* P8_35a */
+	P8_35_default_pin: pinmux_P8_35_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x360C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_35_gpio_pin: pinmux_P8_35_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x360C, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_35_gpio_pu_pin: pinmux_P8_35_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x360C, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_35_gpio_pd_pin: pinmux_P8_35_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x360C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_35_gpio_input_pin: pinmux_P8_35_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x360C, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_35b */
+	P8_35_qep_pin: pinmux_P8_35_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x34E4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE10) >; };	
+
+	/* P8_36a */
+	P8_36_default_pin: pinmux_P8_36_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3604, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_36_gpio_pin: pinmux_P8_36_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3604, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_36_gpio_pu_pin: pinmux_P8_36_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3604, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_36_gpio_pd_pin: pinmux_P8_36_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3604, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_36_gpio_input_pin: pinmux_P8_36_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3604, PIN_INPUT | MUX_MODE14) >; };			
+	
+	/* P8_36b */
+	P8_36_pwm_pin: pinmux_P8_36_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3568, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE10) >; };	/* ?? ehrpwm1a instead we have ehrpwm1b here */
+	
+	/* P8_37a */
+	P8_37_default_pin: pinmux_P8_37_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_37_gpio_pin: pinmux_P8_37_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_37_gpio_pu_pin: pinmux_P8_37_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_37_gpio_pd_pin: pinmux_P8_37_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_37_gpio_input_pin: pinmux_P8_37_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_INPUT | MUX_MODE14) >; };			
+	P8_37_pwm_pin: pinmux_P8_37_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35FC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm1_tripzone_input */
+	
+	/* P8_37b */
+	P8_37_uart_pin: pinmux_P8_37_uart_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3738, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* lcd_data8.uart5_txd */
+
+	/* P8_38a */
+	P8_38_default_pin: pinmux_P8_38_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_38_gpio_pin: pinmux_P8_38_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_38_gpio_pu_pin: pinmux_P8_38_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_38_gpio_pd_pin: pinmux_P8_38_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_38_gpio_input_pin: pinmux_P8_38_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_INPUT | MUX_MODE14) >; };			
+	P8_38_pwm_pin: pinmux_P8_38_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3600, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm0_synco */
+	
+	/* P8_38b */
+	P8_38_uart_pin: pinmux_P8_38_uart_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3734, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* lcd_data9.uart5_rxd */
+
+	/* P8_39 */
+	P8_39_default_pin: pinmux_P8_39_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_39_gpio_pin: pinmux_P8_39_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_39_gpio_pu_pin: pinmux_P8_39_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_39_gpio_pd_pin: pinmux_P8_39_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_39_gpio_input_pin: pinmux_P8_39_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_INPUT | MUX_MODE14) >; };			
+	P8_39_qep_pin: pinmux_P8_39_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2_index */
+	P8_39_pruout_pin: pinmux_P8_39_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_39_pruin_pin: pinmux_P8_39_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F4, PIN_INPUT | MUX_MODE12) >; };			
+
+	/* P8_40 */
+	P8_40_default_pin: pinmux_P8_40_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_40_gpio_pin: pinmux_P8_40_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_40_gpio_pu_pin: pinmux_P8_40_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_40_gpio_pd_pin: pinmux_P8_40_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_40_gpio_input_pin: pinmux_P8_40_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_INPUT | MUX_MODE14) >; };			
+	P8_40_qep_pin: pinmux_P8_40_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2_strobe */
+	P8_40_pruout_pin: pinmux_P8_40_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_40_pruin_pin: pinmux_P8_40_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F8, PIN_INPUT | MUX_MODE12) >; };	
+
+	/* P8_41 */
+	P8_41_default_pin: pinmux_P8_41_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_41_gpio_pin: pinmux_P8_41_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_41_gpio_pu_pin: pinmux_P8_41_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_41_gpio_pd_pin: pinmux_P8_41_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_41_gpio_input_pin: pinmux_P8_41_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_INPUT | MUX_MODE14) >; };			
+	P8_41_qep_pin: pinmux_P8_41_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2a_in */
+	P8_41_pruout_pin: pinmux_P8_41_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_41_pruin_pin: pinmux_P8_41_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35EC, PIN_INPUT | MUX_MODE12) >; };			
+
+	/* P8_42 */
+	P8_42_default_pin: pinmux_P8_42_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_42_gpio_pin: pinmux_P8_42_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_42_gpio_pu_pin: pinmux_P8_42_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_42_gpio_pd_pin: pinmux_P8_42_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_42_gpio_input_pin: pinmux_P8_42_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_INPUT | MUX_MODE14) >; };			
+	P8_42_qep_pin: pinmux_P8_42_qep_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE15) >; };	/* ?? eqep2b_in */
+	P8_42_pruout_pin: pinmux_P8_42_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_42_pruin_pin: pinmux_P8_42_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35F0, PIN_INPUT | MUX_MODE12) >; };	
+
+	/* P8_43 */
+	P8_43_default_pin: pinmux_P8_43_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_43_gpio_pin: pinmux_P8_43_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_43_gpio_pu_pin: pinmux_P8_43_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_43_gpio_pd_pin: pinmux_P8_43_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_43_gpio_input_pin: pinmux_P8_43_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_INPUT | MUX_MODE14) >; };			
+	P8_43_pwm_pin: pinmux_P8_43_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm2_tripzone_input */
+	P8_43_pruout_pin: pinmux_P8_43_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_43_pruin_pin: pinmux_P8_43_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E4, PIN_INPUT | MUX_MODE12) >; };		
+
+	/* P8_44 */
+	P8_44_default_pin: pinmux_P8_44_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_44_gpio_pin: pinmux_P8_44_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_44_gpio_pu_pin: pinmux_P8_44_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_44_gpio_pd_pin: pinmux_P8_44_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_44_gpio_input_pin: pinmux_P8_44_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_INPUT | MUX_MODE14) >; };			
+	P8_44_pwm_pin: pinmux_P8_44_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm0_synco */
+	P8_44_pruout_pin: pinmux_P8_44_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_44_pruin_pin: pinmux_P8_44_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E8, PIN_INPUT | MUX_MODE12) >; };			
+	
+	/* P8_45a */
+	P8_45_default_pin: pinmux_P8_45_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_45_gpio_pin: pinmux_P8_45_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_45_gpio_pu_pin: pinmux_P8_45_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_45_gpio_pd_pin: pinmux_P8_45_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_45_gpio_input_pin: pinmux_P8_45_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_INPUT | MUX_MODE14) >; };			
+	P8_45_pwm_pin: pinmux_P8_45_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35DC, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE15) >; };	/* ?? ehrpwm2a */
+	
+	/* P8_45b */
+	P8_45_pruout_pin: pinmux_P8_45_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x361C, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_45_pruin_pin: pinmux_P8_45_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x361C, PIN_INPUT | MUX_MODE12) >; };		
+
+	/* P8_46a */
+	P8_46_default_pin: pinmux_P8_46_default_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_46_gpio_pin: pinmux_P8_46_gpio_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_OUTPUT | INPUT_EN | MUX_MODE14) >; };		
+	P8_46_gpio_pu_pin: pinmux_P8_46_gpio_pu_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	
+	P8_46_gpio_pd_pin: pinmux_P8_46_gpio_pd_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	
+	P8_46_gpio_input_pin: pinmux_P8_46_gpio_input_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_INPUT | MUX_MODE14) >; };			
+	P8_46_pwm_pin: pinmux_P8_46_pwm_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x35E0, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE3) >; };	/* ?? ehrpwm2b */
+	
+	/* P8_46b */
+	P8_46_pruout_pin: pinmux_P8_46_pruout_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3638, PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE13) >; };	
+	P8_46_pruin_pin: pinmux_P8_46_pruin_pin { pinctrl-single,pins = <
+		DRA7XX_CORE_IOPAD(0x3638, PIN_INPUT | MUX_MODE12) >; };			
+
+	
 	extcon_usb1_pins_default: extcon_usb1_pins_default {
 		pinctrl-single,pins = <
 			DRA7XX_CORE_IOPAD(0x3518, PIN_INPUT | MUX_MODE14) /* AG2: vin1a_d9.gpio3_13  - USR0 */


### PR DESCRIPTION
This change is a step towards making the capes compatible with both BBBlack and BBAi. I have included all the P8 header pin muxing nodes. Some of the pins that are attached to eQEP and PWM peripherals of AM572x require editing. I have included /* ?? ... */ at the end of nodes that are not final and require editing (which I will do soon). some functionalities are present on a different pin of AM572x than AM335x and we have to shift them accordingly.

```
Example: eqep1_strobe available on 
P9_21 of AM572X 
P8_32 of AM335X
```

I will create a new commit for P9 header before editing the nodes of P8 header. 

@jadonk @RobertCNelson please review the commit and let me know the required changes if any.

