### PR TITLE
Peripheral aliases for BeagleBone AI

### DIFF
--- a/src/arm/am5729-beagleboneai.dts
+++ b/src/arm/am5729-beagleboneai.dts
@@ -19,6 +19,22 @@
 		     "ti,dra742", "ti,dra74", "ti,dra7";
 
 	aliases {
+		// I2C
+		bone-i2c1 = &i2c5;
+		bone-i2c2 = &i2c4;
+		bone-i2c3 = &i2c3;
+		// SPI
+		bone-spi0 = &spi2;
+		bone-spi1 = &spi3;
+		// UART
+		bone-serial0 = &uart1;
+		bone-serial1 = &uart10;
+		bone-serial2 = &uart3;
+		bone-serial4 = &uart5;
+		bone-serial5 = &uart8;
+		// CAN
+		bone-d-can1 = &dcan2; 
+
 		rtc0 = &tps659038_rtc;
 		rtc1 = &rtc;
 		display0 = &hdmi_conn;

--- a/src/arm/am5729-beagleboneai.dts
+++ b/src/arm/am5729-beagleboneai.dts
@@ -24,8 +24,7 @@
 		bone-i2c2 = &i2c4;
 		bone-i2c3 = &i2c3;
 		// SPI
-		bone-spi0 = &spi2;
-		bone-spi1 = &spi3;
+		bone-spi0 = &qspi;
 		// UART
 		bone-serial0 = &uart1;
 		bone-serial1 = &uart10;


### PR DESCRIPTION
Added some aliases for the BeagleBone AI board. @RobertCNelson please review the code, I talked to @jadonk and we think that it's better to give the BeagleBone AI aliases in the format `bone-peripheral#`. What is your thought on that? Actually, the thing is we already have aliases for peripherals in `dra7.dtsi` but not all the peripherals are available on the BeagleBoneAI board and those are available are not in sync with BeagleBone cape interface spec-. for example, looking in the `dra7.dtsi` the file we these aliases for I2C:

```
i2c0 = &i2c1;
i2c1 = &i2c2;
i2c2 = &i2c3;
i2c3 = &i2c4;
i2c4 = &i2c5;
```

Out of these we only have i2c3, i2c4 and i2c5 available on the BeagleBoneAI board. Similar situation for other peripherals. Taking everything in account the correct aliases for BeagleBoneAI should be:

```
bone-i2c1 = &i2c5;
bone-i2c2 = &i2c4;
bone-i2c3 = &i2c3;
```
With this pull request, I have included some of the aliases and will include remaining as I progress :)