### PR TITLE
Remove aliases and add symlink

### DIFF
--- a/src/arm/am5729-beagleboneai.dts
+++ b/src/arm/am5729-beagleboneai.dts
@@ -19,21 +19,6 @@
 		     "ti,dra742", "ti,dra74", "ti,dra7";
 
 	aliases {
-		// I2C
-		bone-i2c1 = &i2c5;
-		bone-i2c2 = &i2c4;
-		bone-i2c3 = &i2c3;
-		// SPI
-		bone-spi0 = &qspi;
-		// UART
-		bone-serial0 = &uart1;
-		bone-serial1 = &uart10;
-		bone-serial2 = &uart3;
-		bone-serial4 = &uart5;
-		bone-serial5 = &uart8;
-		// CAN
-		bone-d-can1 = &dcan2; 
-
 		rtc0 = &tps659038_rtc;
 		rtc1 = &rtc;
 		display0 = &hdmi_conn;
@@ -2402,6 +2387,7 @@
 &i2c4 {
 	status = "okay";
 	clock-frequency = <100000>;
+	symlink = "bone-i2c2";
 };
 
 /* thermal hacks */


### PR DESCRIPTION
@RobertCNelson, let's try this :)

I don't want to edit the `dra7.dtsi` at this moment and it seems all the peripheral nodes are in there and most of them are disabled. I will create new nodes for them in `am5729-beagleboneai.dts` with `status = okay` after we figure this out.