### PR TITLE
Compatibility update4

### DIFF
--- a/src/arm/bbai-bone-buses.dtsi
+++ b/src/arm/bbai-bone-buses.dtsi
@@ -546,3 +546,110 @@ bone_emmc: &mmc3 {
 	vmmc-supply = <&vdd_1v8>;
 	bus-width = <8>;
 };
+
+// LCD
+// Display Sub System (DSS)
+&dss {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port {
+			reg = <0>;
+
+			dpi_out: endpoint {
+				data-lines = <16>;
+				remote-endpoint = <&lcd_in>;
+			};
+		};
+	};
+};
+
+// Touch Controller
+&bone_i2c_1 {
+	status = "okay";
+	clock-frequency = <100000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	// Bone Touch controller
+	bone_polytouch_edt: edt-ft5x06@38 {
+		status = "disabled";
+		compatible = "edt,edt-ft5x06";
+		reg = <0x38>;
+		interrupt-parent = <&gpio6>;
+		interrupts = <14 2>;
+		touchscreen-size-y = <480>;
+		touchscreen-size-x = <272>;
+		touchscreen-swapped-x-y;
+	};
+};
+
+&{/} {
+
+	// Backlight(s)
+	// Backlight on pin P9_14
+	bone_backlight: backlight {
+		status = "disabled";
+		compatible = "pwm-backlight";
+		pwms = <&bone_pwm_1 0 500000 0>;
+		brightness-levels = <
+			0  1  2  3  4  5  6  7  8  9
+			10 11 12 13 14 15 16 17 18 19
+			20 21 22 23 24 25 26 27 28 29
+			30 31 32 33 34 35 36 37 38 39
+			40 41 42 43 44 45 46 47 48 49
+			50 51 52 53 54 55 56 57 58 59
+			60 61 62 63 64 65 66 67 68 69
+			70 71 72 73 74 75 76 77 78 79
+			80 81 82 83 84 85 86 87 88 89
+			90 91 92 93 94 95 96 97 98 99
+			100
+		>;
+		default-brightness-level = <100>;
+	};
+
+	// Display(s)
+	// 4D Systems GEN4-4DCAPE-43CT-CLB Cape
+	bone_lcd_4d4c: display {
+		status = "disabled";
+		compatible = "qiaodian,qd43003c0-40", "panel-dpi";
+		backlight = <&bone_backlight>;
+		enable-gpios = <&gpio2 5 0>;
+		label = "lcd";
+
+		panel-info {
+			ac-bias           = <255>;
+			ac-bias-intrpt    = <0>;
+			dma-burst-sz      = <16>;
+			bpp               = <16>;
+			fdd               = <0x80>;
+			sync-edge         = <0>;
+			sync-ctrl         = <1>;
+			raster-order      = <0>;
+			fifo-th           = <0>;
+		};
+
+		panel-timing {
+			clock-frequency = <9200000>;
+			hactive = <480>;
+			vactive = <272>;
+			hfront-porch = <8>;
+			hback-porch = <47>;
+			hsync-len = <41>;
+			vback-porch = <2>;
+			vfront-porch = <3>;
+			vsync-len = <10>;
+			hsync-active = <0>;
+			vsync-active = <0>;
+			de-active = <1>;
+			pixelclk-active = <0>;
+		};
+
+		port {
+			lcd_in: endpoint {
+				remote-endpoint = <&dpi_out>;
+			};
+		};
+	};
+};

--- a/src/arm/bbb-bone-buses.dtsi
+++ b/src/arm/bbb-bone-buses.dtsi
@@ -1,5 +1,7 @@
 /*
  * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
  * See Cape Interface Spec page for more info on Bone Buses
  * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
  *
@@ -576,4 +578,104 @@ bone_emmc: &mmc2 {
 	status = "disabled";
 	vmmc-supply = <&vmmcsd_fixed>;
 	bus-width = <8>;
+};
+
+// LCD
+// AM33xx LCD Interface
+&lcdc {
+	status = "okay";
+};
+
+// Touch Controller
+&bone_i2c_1 {
+	status = "okay";
+	clock-frequency = <100000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	// Bone Touch controller
+	bone_polytouch_edt: edt-ft5x06@38 {
+		status = "disabled";
+		compatible = "edt,edt-ft5x06";
+		reg = <0x38>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <14 2>;
+		touchscreen-size-y = <480>;
+		touchscreen-size-x = <272>;
+		touchscreen-swapped-x-y;
+	};
+};
+
+&{/} {
+
+	// Backlight(s)
+	// Backlight on pin P9_14
+	bone_backlight: backlight {
+		status = "disabled";
+		compatible = "pwm-backlight";
+		pwms = <&bone_pwm_1 0 500000 0>;
+		brightness-levels = <
+			0  1  2  3  4  5  6  7  8  9
+			10 11 12 13 14 15 16 17 18 19
+			20 21 22 23 24 25 26 27 28 29
+			30 31 32 33 34 35 36 37 38 39
+			40 41 42 43 44 45 46 47 48 49
+			50 51 52 53 54 55 56 57 58 59
+			60 61 62 63 64 65 66 67 68 69
+			70 71 72 73 74 75 76 77 78 79
+			80 81 82 83 84 85 86 87 88 89
+			90 91 92 93 94 95 96 97 98 99
+			100
+		>;
+		default-brightness-level = <100>;
+	};
+
+	// Displays(s)
+	// 4D Systems GEN4-4DCAPE-43CT-CLB Cape
+	bone_lcd_4d4c: panel {
+		status = "disabled";
+		compatible = "ti,tilcdc,panel";
+		backlight = <&bone_backlight>;
+
+		panel-info {
+			ac-bias           = <255>;
+			ac-bias-intrpt    = <0>;
+			dma-burst-sz      = <16>;
+			bpp               = <16>;
+			fdd               = <0x80>;
+			sync-edge         = <0>;
+			sync-ctrl         = <1>;
+			raster-order      = <0>;
+			fifo-th           = <0>;
+		};
+		
+		display-timings {
+			native-mode = <&timing0>;
+			/* www.newhavendisplay.com/app_notes/OTA5180A.pdf */
+			timing0: 480x272 {
+				clock-frequency = <9200000>;
+				hactive = <480>;
+				vactive = <272>;
+				hfront-porch = <8>;
+				hback-porch = <47>;
+				hsync-len = <41>;
+				vback-porch = <2>;
+				vfront-porch = <3>;
+				vsync-len = <10>;
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <1>;
+				pixelclk-active = <0>;
+			};
+		};
+	};
+
+	// Frame Buffer AM33XX
+	fb {
+		compatible = "ti,am33xx-tilcdc";
+		reg = <0x4830e000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <36>;
+		ti,hwmods = "lcdc";
+	};
 };

--- a/src/arm/overlays/BB-BONE-4D4C-01-00A1.dts
+++ b/src/arm/overlays/BB-BONE-4D4C-01-00A1.dts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * Overlay for 4D Systems GEN4-4DCAPE-43CT-CLB Cape and similar Displays
+ * Compatible with BBB, BBBWL, and BBAI
+ *
+ * Based on older BB-BONE-4D4C-01-00A1.dts from TI for kernel < 4.14
+ * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+ 
+&{/chosen} {
+	overlays {
+		BB-BONE-4D4C-01-00A1 = __TIMESTAMP__;
+	};
+};
+ 
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+	P8_45_pinmux { pinctrl-0 = <&P8_45_lcd_pin>;};	/* lcd: lcd_data0 */
+	P8_46_pinmux { pinctrl-0 = <&P8_46_lcd_pin>;};	/* lcd: lcd_data1 */
+	P8_43_pinmux { pinctrl-0 = <&P8_43_lcd_pin>;};	/* lcd: lcd_data2 */
+	P8_44_pinmux { pinctrl-0 = <&P8_44_lcd_pin>;};	/* lcd: lcd_data3 */
+	P8_41_pinmux { pinctrl-0 = <&P8_41_lcd_pin>;};	/* lcd: lcd_data4 */
+	P8_42_pinmux { pinctrl-0 = <&P8_42_lcd_pin>;};	/* lcd: lcd_data5 */
+	P8_39_pinmux { pinctrl-0 = <&P8_39_lcd_pin>;};	/* lcd: lcd_data6 */
+	P8_40_pinmux { pinctrl-0 = <&P8_40_lcd_pin>;};	/* lcd: lcd_data7 */
+	P8_37_pinmux { pinctrl-0 = <&P8_37_lcd_pin>;};	/* lcd: lcd_data8 */
+	P8_38_pinmux { pinctrl-0 = <&P8_38_lcd_pin>;};	/* lcd: lcd_data9 */
+	P8_36_pinmux { pinctrl-0 = <&P8_36_lcd_pin>;};	/* lcd: lcd_data10 */
+	P8_34_pinmux { pinctrl-0 = <&P8_34_lcd_pin>;};	/* lcd: lcd_data11 */
+	P8_35_pinmux { pinctrl-0 = <&P8_35_lcd_pin>;};	/* lcd: lcd_data12 */
+	P8_33_pinmux { pinctrl-0 = <&P8_33_lcd_pin>;};	/* lcd: lcd_data13 */
+	P8_31_pinmux { pinctrl-0 = <&P8_31_lcd_pin>;};	/* lcd: lcd_data14 */
+	P8_32_pinmux { pinctrl-0 = <&P8_32_lcd_pin>;};	/* lcd: lcd_data15 */
+ 
+	P8_27_pinmux { pinctrl-0 = <&P8_27_lcd_pin>;};	/* lcd: lcd_vsync */
+	P8_29_pinmux { pinctrl-0 = <&P8_29_lcd_pin>;};	/* lcd: lcd_hsync */
+	P8_28_pinmux { pinctrl-0 = <&P8_28_lcd_pin>;};	/* lcd: lcd_pclk */
+	P8_30_pinmux { pinctrl-0 = <&P8_30_lcd_pin>;};	/* lcd: lcd_ac_bias_en */
+ 
+	P9_27_pinmux { pinctrl-0 = <&P9_27_gpio_pin>;};	/* lcd: gpio3_19 DISPEN */
+ 
+	P9_14_pinmux { pinctrl-0 = <&P9_14_pwm_pin>;};	/* pwm: ehrpwm1a PWM_BL */
+ 
+	P9_18_pinmux { pinctrl-0 = <&P9_18_i2c_pin>;};	/* i2c1_sda */
+	P9_17_pinmux { pinctrl-0 = <&P9_17_i2c_pin>;};	/* i2c1_scl */
+	P9_26_pinmux { pinctrl-0 = <&P9_26_gpio_pin>;};	/* touch interrupt on gpio0_14 */
+};
+
+/*
+ * See these files for the phandles (&bone_*) and other bone bus nodes
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbai-bone-buses.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbb-bone-buses.dtsi
+ */
+
+// PWM for Backlight
+&bone_pwm_1{
+	status = "okay";
+};
+
+// Touch Controller
+&bone_polytouch_edt {
+	status = "okay";
+};
+
+// Backlight
+&bone_backlight {
+	status = "okay";
+};
+
+// LCD
+&bone_lcd_4d4c {
+	status = "okay";
+};

--- a/src/arm/overlays/BBAI-4D4C-00A1.dts
+++ b/src/arm/overlays/BBAI-4D4C-00A1.dts
@@ -1,9 +1,14 @@
 /*
  * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
  * See Cape Interface Spec page for more info on Bone Buses
  * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
  *
- * Overlay for 4D Systems GEN4-4DCAPE-43CT-CLB and similar Displays
+ * BBBAI Overlay for 4D Systems GEN4-4DCAPE-43CT-CLB Cape and similar Displays
+ *
+ * Based on older BB-BONE-4D4C-01-00A1.dts from TI for kernel < 4.14
+ * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as

--- a/src/arm/overlays/BBB-4D4C-00A1.dts
+++ b/src/arm/overlays/BBB-4D4C-00A1.dts
@@ -53,13 +53,13 @@
 	P8_28_pinmux { pinctrl-0 = <&P8_28_lcd_pin>;};	/* lcd: lcd_pclk */
 	P8_30_pinmux { pinctrl-0 = <&P8_30_lcd_pin>;};	/* lcd: lcd_ac_bias_en */
  
-	P9_27_pinmux { pinctrl-0 = <&P9_27_gpio_pin>;};	/* lcd: DISPEN */
+	P9_27_pinmux { pinctrl-0 = <&P9_27_gpio_pin>;};	/* lcd: gpio3_19 DISPEN */
  
 	P9_14_pinmux { pinctrl-0 = <&P9_14_pwm_pin>;};	/* pwm: ehrpwm1a PWM_BL */
  
 	P9_18_pinmux { pinctrl-0 = <&P9_18_i2c_pin>;};	/* i2c1_sda */
 	P9_17_pinmux { pinctrl-0 = <&P9_17_i2c_pin>;};	/* i2c1_scl */
-	P9_26_pinmux { pinctrl-0 = <&P9_26_gpio_pin>;};	/* touch interrupt on gpio6_14 */
+	P9_26_pinmux { pinctrl-0 = <&P9_26_gpio_pin>;};	/* touch interrupt on gpio0_14 */
 };
 
 /*
@@ -99,7 +99,7 @@
 &{/} {
 
 	// Backlight
-	lcd_bl: backlight {
+	backlight {
 		status = "okay";
 		compatible = "pwm-backlight";
 		pwms = <&bone_pwm_1 0 500000 0>;

--- a/src/arm/overlays/BBB-4D4C-00A1.dts
+++ b/src/arm/overlays/BBB-4D4C-00A1.dts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * BBB Overlay for 4D Systems GEN4-4DCAPE-43CT-CLB Cape and similar Displays
+ *
+ * Based on older BB-BONE-4D4C-01-00A1.dts from TI for kernel < 4.14
+ * Copyright (C) 2012 Texas Instruments Incorporated - http://www.ti.com/
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+ 
+&{/chosen} {
+	overlays {
+		BBB-4D4C-00A1 = __TIMESTAMP__;
+	};
+};
+ 
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+	P8_45_pinmux { pinctrl-0 = <&P8_45_lcd_pin>;};	/* lcd: lcd_data0 */
+	P8_46_pinmux { pinctrl-0 = <&P8_46_lcd_pin>;};	/* lcd: lcd_data1 */
+	P8_43_pinmux { pinctrl-0 = <&P8_43_lcd_pin>;};	/* lcd: lcd_data2 */
+	P8_44_pinmux { pinctrl-0 = <&P8_44_lcd_pin>;};	/* lcd: lcd_data3 */
+	P8_41_pinmux { pinctrl-0 = <&P8_41_lcd_pin>;};	/* lcd: lcd_data4 */
+	P8_42_pinmux { pinctrl-0 = <&P8_42_lcd_pin>;};	/* lcd: lcd_data5 */
+	P8_39_pinmux { pinctrl-0 = <&P8_39_lcd_pin>;};	/* lcd: lcd_data6 */
+	P8_40_pinmux { pinctrl-0 = <&P8_40_lcd_pin>;};	/* lcd: lcd_data7 */
+	P8_37_pinmux { pinctrl-0 = <&P8_37_lcd_pin>;};	/* lcd: lcd_data8 */
+	P8_38_pinmux { pinctrl-0 = <&P8_38_lcd_pin>;};	/* lcd: lcd_data9 */
+	P8_36_pinmux { pinctrl-0 = <&P8_36_lcd_pin>;};	/* lcd: lcd_data10 */
+	P8_34_pinmux { pinctrl-0 = <&P8_34_lcd_pin>;};	/* lcd: lcd_data11 */
+	P8_35_pinmux { pinctrl-0 = <&P8_35_lcd_pin>;};	/* lcd: lcd_data12 */
+	P8_33_pinmux { pinctrl-0 = <&P8_33_lcd_pin>;};	/* lcd: lcd_data13 */
+	P8_31_pinmux { pinctrl-0 = <&P8_31_lcd_pin>;};	/* lcd: lcd_data14 */
+	P8_32_pinmux { pinctrl-0 = <&P8_32_lcd_pin>;};	/* lcd: lcd_data15 */
+ 
+	P8_27_pinmux { pinctrl-0 = <&P8_27_lcd_pin>;};	/* lcd: lcd_vsync */
+	P8_29_pinmux { pinctrl-0 = <&P8_29_lcd_pin>;};	/* lcd: lcd_hsync */
+	P8_28_pinmux { pinctrl-0 = <&P8_28_lcd_pin>;};	/* lcd: lcd_pclk */
+	P8_30_pinmux { pinctrl-0 = <&P8_30_lcd_pin>;};	/* lcd: lcd_ac_bias_en */
+ 
+	P9_27_pinmux { pinctrl-0 = <&P9_27_gpio_pin>;};	/* lcd: DISPEN */
+ 
+	P9_14_pinmux { pinctrl-0 = <&P9_14_pwm_pin>;};	/* pwm: ehrpwm1a PWM_BL */
+ 
+	P9_18_pinmux { pinctrl-0 = <&P9_18_i2c_pin>;};	/* i2c1_sda */
+	P9_17_pinmux { pinctrl-0 = <&P9_17_i2c_pin>;};	/* i2c1_scl */
+	P9_26_pinmux { pinctrl-0 = <&P9_26_gpio_pin>;};	/* touch interrupt on gpio6_14 */
+};
+
+/*
+ * See these files for the phandles (&bone_*) and other bone bus nodes
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbai-bone-buses.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbb-bone-buses.dtsi
+ */
+
+// PWM Backlight
+&bone_pwm_1{
+	status = "okay";
+};
+
+// Touch Controller
+&bone_i2c_1 {
+	status = "okay";
+	clock-frequency = <100000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	polytouch: edt-ft5x06@38 {
+		compatible = "edt,edt-ft5x06";
+		reg = <0x38>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <14 2>;
+		touchscreen-size-y = <480>;
+		touchscreen-size-x = <272>;
+		touchscreen-swapped-x-y;
+	};
+};
+
+// LCD Interface
+&lcdc {
+	status = "okay";
+};
+
+&{/} {
+
+	// Backlight
+	lcd_bl: backlight {
+		status = "okay";
+		compatible = "pwm-backlight";
+		pwms = <&bone_pwm_1 0 500000 0>;
+		brightness-levels = <
+			0  1  2  3  4  5  6  7  8  9
+			10 11 12 13 14 15 16 17 18 19
+			20 21 22 23 24 25 26 27 28 29
+			30 31 32 33 34 35 36 37 38 39
+			40 41 42 43 44 45 46 47 48 49
+			50 51 52 53 54 55 56 57 58 59
+			60 61 62 63 64 65 66 67 68 69
+			70 71 72 73 74 75 76 77 78 79
+			80 81 82 83 84 85 86 87 88 89
+			90 91 92 93 94 95 96 97 98 99
+			100
+		>;
+		default-brightness-level = <100>;
+	};
+
+	// LCD
+	panel {
+		status = "okay";
+		compatible = "ti,tilcdc,panel";
+
+		panel-info {
+			ac-bias           = <255>;
+			ac-bias-intrpt    = <0>;
+			dma-burst-sz      = <16>;
+			bpp               = <16>;
+			fdd               = <0x80>;
+			sync-edge         = <0>;
+			sync-ctrl         = <1>;
+			raster-order      = <0>;
+			fifo-th           = <0>;
+		};
+		
+		display-timings {
+			native-mode = <&timing0>;
+			/* www.newhavendisplay.com/app_notes/OTA5180A.pdf */
+			timing0: 480x272 {
+				clock-frequency = <9200000>;
+				hactive = <480>;
+				vactive = <272>;
+				hfront-porch = <8>;
+				hback-porch = <47>;
+				hsync-len = <41>;
+				vback-porch = <2>;
+				vfront-porch = <3>;
+				vsync-len = <10>;
+				hsync-active = <0>;
+				vsync-active = <0>;
+				de-active = <1>;
+				pixelclk-active = <0>;
+			};
+		};
+	};
+
+	fb {
+		compatible = "ti,am33xx-tilcdc";
+		reg = <0x4830e000 0x1000>;
+		interrupt-parent = <&intc>;
+		interrupts = <36>;
+		ti,hwmods = "lcdc";
+	};
+};

--- a/src/arm/overlays/BONE-LED_P8_03.dts
+++ b/src/arm/overlays/BONE-LED_P8_03.dts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * Virtual cape for LED on P8_03 
+ * Supports BBB, BBBWL, and BBAI
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+ 
+&{/chosen} {
+	overlays {
+		BONE-LED_P8_03 = __TIMESTAMP__;
+	};
+};
+ 
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+	P8_03_pinmux { pinctrl-0 = <&P8_03_gpio_pin>;};	/* lcd: lcd_data0 */
+};
+
+/*
+ * Easy LED control through sysfs (/sys/class/leds/) using gpio-leds driver
+ * See these files for the led_P8_#/led_P9_#  definition
+ * https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbai-bone-buses.dtsi
+ * https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbb-bone-buses.dtsi
+ * 
+ */
+
+&{/} {
+	leds {
+		led_P8_03 {
+			status = "okay";
+			label = "led_P8_03"; // sys/class/leds/<label>
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+		};
+	};
+};

--- a/src/arm/overlays/BONE-LED_P9_11.dts
+++ b/src/arm/overlays/BONE-LED_P9_11.dts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * Virtual cape for LED on P9_11 
+ * Supports BBB, BBBWL, and BBAI
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+ 
+&{/chosen} {
+	overlays {
+		BONE-LED_P9_11 = __TIMESTAMP__;
+	};
+};
+ 
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+	P9_11_pinmux { pinctrl-0 = <&P9_11_gpio_pin>;};	/* lcd: lcd_data0 */
+};
+
+/*
+ * Easy LED control through sysfs (/sys/class/leds/) using gpio-leds driver
+ * See these files for the led_P8_#/led_P9_#  definition
+ * https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbai-bone-buses.dtsi
+ * https://github.com/beagleboard/BeagleBoard-DeviceTrees/src/arm/bbb-bone-buses.dtsi
+ * 
+ */
+
+&{/} {
+	leds {
+		led_P9_11 {
+			status = "okay";
+			label = "led_P9_11"; // sys/class/leds/<label>
+			linux,default-trigger = "heartbeat";
+			default-state = "on";
+		};
+	};
+};

--- a/src/arm/overlays/Makefile
+++ b/src/arm/overlays/Makefile
@@ -1,6 +1,7 @@
 # Overlays for the BeagleBone platform
 
 dtbo-$(CONFIG_SOC_AM33XX) += \
+	BB-BONE-4D4C-01-00A1.dtbo \
 	BB-CTAG-SW-8CH-00A0.dtbo \
 	BBAI-eCAP1.dtbo \
 	BBAI-eCAP2.dtbo \
@@ -19,6 +20,7 @@ dtbo-$(CONFIG_SOC_AM33XX) += \
 	BBAI-PRUOUT_PRU1_1.dtbo \
 	BBAI-PRUOUT_PRU2_0.dtbo \
 	BBAI-PRUOUT_PRU2_1.dtbo \
+	BBB-4D4C-00A1.dtbo \
 	BBB-eCAP0.dtbo \
 	BBB-eCAP2.dtbo \
 	BBB-PRU_eCAP.dtbo \
@@ -41,6 +43,8 @@ dtbo-$(CONFIG_SOC_AM33XX) += \
 	BONE-I2C2.dtbo \
 	BONE-I2C2A.dtbo \
 	BONE-I2C3.dtbo \
+	BONE-LED_P8_03.dtbo \
+	BONE-LED_P9_11.dtbo \
 	BONE-PRU_eCAP.dtbo \
 	BONE-PWM0.dtbo \
 	BONE-PWM1.dtbo \


### PR DESCRIPTION
@RobertCNelson @jadonk please review my code :) Everything has been tested on BBBWL and BBAI.

This update brings 
1. A new compatibile DT overlay for 4.3" LCD cape (4D Systems GEN4-4DCAPE-43CT-CLB).
2. BBB/BBBWL only DT overlay for 4.3" LCD cape (4D Systems GEN4-4DCAPE-43CT-CLB).
3. Overlays for Bone LED on P8 and P9 header, can be used as template for LED projects.