### PR TITLE
Add BBAI-SPI0_1.dts (Fix #24)

### DIFF
--- a/src/arm/am572x-bone-common-univ.dtsi
+++ b/src/arm/am572x-bone-common-univ.dtsi
@@ -1316,6 +1316,8 @@
 		P9_23( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE14) >; };	/* spi1_cs1.gpio7_11 */
 	P9_23_gpio_pd_pin: pinmux_P9_23_gpio_pd_pin { pinctrl-single,pins = <
 		P9_23( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE14) >; };	/* spi1_cs1.gpio7_11 */
+	P9_23_spi_cs_pin: pinmux_P9_23_spi_cs_pin { pinctrl-single,pins = <
+		P9_23( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE3) >; };	/* spi1_cs1.spi2_cs1 */
 
 	/* P9_24  (ball F20) gpio6_15*/
 	P9_24_default_pin: pinmux_P9_24_default_pin { pinctrl-single,pins = <

--- a/src/arm/overlays/BBAI-SPI0_1.dts
+++ b/src/arm/overlays/BBAI-SPI0_1.dts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * https://lorforlinux.github.io/GSoC2020_BeagleBoard.org/
+ *
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * BBAI Virtual cape for /dev/bone/spi/0.1
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BBAI-SPI0_1 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P9_23_pinmux { pinctrl-0 = <&P9_23_spi_cs_pin>; }; /* CS */
+    P9_18_pinmux { pinctrl-0 = <&P9_18_spi_pin>; }; /* MOSI */
+    P9_21_pinmux { pinctrl-0 = <&P9_21_spi_pin>; }; /* MISO */
+    P9_22_pinmux { pinctrl-0 = <&P9_22_spi_sclk_pin>; }; /* CLK */
+};
+
+/*
+ * See these files for the phandles (&bone_*) and other bone bus nodes
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbai-bone-buses.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbb-bone-buses.dtsi
+ */
+&bone_spi_0 {
+	status = "okay";
+    #address-cells = <1>;
+    #size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		compatible = "spidev";
+		symlink = "bone/spi/0.1";
+		spi-max-frequency = <16000000>;
+        spi-cpha;
+	};
+};

--- a/src/arm/overlays/Makefile
+++ b/src/arm/overlays/Makefile
@@ -20,6 +20,7 @@ dtbo-$(CONFIG_SOC_AM33XX) += \
 	BBAI-PRUOUT_PRU1_1.dtbo \
 	BBAI-PRUOUT_PRU2_0.dtbo \
 	BBAI-PRUOUT_PRU2_1.dtbo \
+	BBAI-SPI0_1.dtbo \
 	BBB-4D4C-00A1.dtbo \
 	BBB-eCAP0.dtbo \
 	BBB-eCAP2.dtbo \


### PR DESCRIPTION
@RobertCNelson @jadonk Please review my code :) Everything has been tested on BBAI.

This PR includes DT overlay for enabling channel@1 of bone_spi0 (only available on BBAI) which fixes #24 