### PR TITLE
Fix wrong pin mapping for eQEP0

### DIFF
--- a/src/arm/am335x-boneblue.dts
+++ b/src/arm/am335x-boneblue.dts
@@ -344,7 +344,7 @@
 	/* E1 */
 	eqep0_pins: pinmux_eqep0_pins {
 		pinctrl-single,pins = <
-			AM33XX_PADCONF(AM335X_PIN_MCASP0_AXR0, PIN_INPUT, MUX_MODE1)		/* (B12) mcasp0_aclkr.eQEP0A_in */
+			AM33XX_PADCONF(AM335X_PIN_MCASP0_ACLKR, PIN_INPUT, MUX_MODE1)		/* (B12) mcasp0_aclkr.eQEP0A_in */
 			AM33XX_PADCONF(AM335X_PIN_MCASP0_FSR, PIN_INPUT, MUX_MODE1)		/* (C13) mcasp0_fsr.eQEP0B_in */
 		>;
 	};


### PR DESCRIPTION
This fixes the issue with encoder returning only -1, 0 and 1.
It also fixes the issue with P9_30_pinmux error when booting.