### PR TITLE
GPMC modes added in bone-common in univ | BeagleWire overlays added 

### DIFF
--- a/src/arm/am335x-bone-common-univ.dtsi
+++ b/src/arm/am335x-bone-common-univ.dtsi
@@ -26,6 +26,8 @@
 		P8_03( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad6.gpio1_6 */
 	P8_03_mmc_pin: pinmux_P8_03_mmc_pin { pinctrl-single,pins = <
 		P8_03( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad6.mmc1_dat6 */
+	P8_03_gpmc_pin: pinmux_P8_03_gpmc_pin { pinctrl-single,pins = <
+		P8_03( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad6.gpmc_ad6*/
 
 	/* P8_04 (ZCZ ball T9) emmc */
 	P8_04_default_pin: pinmux_P8_04_default_pin { pinctrl-single,pins = <
@@ -38,6 +40,8 @@
 		P8_04( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad7.gpio1_7 */
 	P8_04_mmc_pin: pinmux_P8_04_mmc_pin { pinctrl-single,pins = <
 		P8_04( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad7.mmc1_dat7 */
+	P8_04_gpmc_pin: pinmux_P8_04_gpmc_pin { pinctrl-single,pins = <
+		P8_04( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad7.gpmc_ad7*/
 
 	/* P8_05 (ZCZ ball R8) emmc */
 	P8_05_default_pin: pinmux_P8_05_default_pin { pinctrl-single,pins = <
@@ -50,6 +54,8 @@
 		P8_05( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad2.gpio1_2 */
 	P8_05_mmc_pin: pinmux_P8_05_mmc_pin { pinctrl-single,pins = <
 		P8_05( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad2.mmc1_dat2 */
+	P8_05_gpmc_pin: pinmux_P8_05_gpmc_pin { pinctrl-single,pins = <
+		P8_05( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad2.gpmc_ad2*/
 
 	/* P8_05 dummy nodes for unavailable bone bus pins*/
 	P8_05_eqep_pin: pinmux_P8_05_eqep_pin { pinctrl-single,pins = <
@@ -68,6 +74,8 @@
 		P8_06( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad3.gpio1_3 */
 	P8_06_mmc_pin: pinmux_P8_06_mmc_pin { pinctrl-single,pins = <
 		P8_06( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad3.mmc1_dat3 */
+	P8_06_gpmc_pin: pinmux_P8_06_gpmc_pin { pinctrl-single,pins = <
+		P8_06( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad3.gpmc_ad3*/
 
 	/* P8_06 dummy nodes for unavailable bone bus pins*/
 	P8_06_eqep_pin: pinmux_P8_06_eqep_pin { pinctrl-single,pins = <
@@ -86,6 +94,8 @@
 		P8_07( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_advn_ale.gpio2_2 */
 	P8_07_timer_pin: pinmux_P8_07_timer_pin { pinctrl-single,pins = <
 		P8_07( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2) >; };	/* gpmc_advn_ale.timer4 */
+	P8_07_gpmc_pin: pinmux_P8_07_gpmc_pin { pinctrl-single,pins = <
+		P8_07( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_advn_ale.gpmc_advn_ale*/
 
 	/* P8_08 (ZCZ ball T7) gpio2_3 */
 	P8_08_default_pin: pinmux_P8_08_default_pin { pinctrl-single,pins = <
@@ -98,6 +108,8 @@
 		P8_08( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_oen_ren.gpio2_3 */
 	P8_08_timer_pin: pinmux_P8_08_timer_pin { pinctrl-single,pins = <
 		P8_08( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2) >; };	/* gpmc_oen_ren.timer7 */
+	P8_08_gpmc_pin: pinmux_P8_08_gpmc_pin { pinctrl-single,pins = <
+		P8_08( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_oen_ren.gpmc_oen_ren*/
 
 	/* P8_09 (ZCZ ball T6) gpio2_5 */
 	P8_09_default_pin: pinmux_P8_09_default_pin { pinctrl-single,pins = <
@@ -110,6 +122,8 @@
 		P8_09( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_be0n_cle.gpio2_5 */
 	P8_09_timer_pin: pinmux_P8_09_timer_pin { pinctrl-single,pins = <
 		P8_09( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2) >; };	/* gpmc_be0n_cle.timer5 */
+	P8_09_gpmc_pin: pinmux_P8_09_gpmc_pin { pinctrl-single,pins = <
+		P8_09( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_be0n_cle.gpmc_be0n_cle*/
 
 	/* P8_10 (ZCZ ball U6) gpio2_4 */
 	P8_10_default_pin: pinmux_P8_10_default_pin { pinctrl-single,pins = <
@@ -122,6 +136,8 @@
 		P8_10( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_wen.gpio2_4 */
 	P8_10_timer_pin: pinmux_P8_10_timer_pin { pinctrl-single,pins = <
 		P8_10( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE2) >; };	/* gpmc_wen.timer6 */
+	P8_10_gpmc_pin: pinmux_P8_10_gpmc_pin { pinctrl-single,pins = <
+		P8_10( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_wen.gpmc_wen*/
 
 	/* P8_11 (ZCZ ball R12) gpio1_13 */
 	P8_11_default_pin: pinmux_P8_11_default_pin { pinctrl-single,pins = <
@@ -136,6 +152,8 @@
 		P8_11( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad13.eqep2b_in */
 	P8_11_pruout_pin: pinmux_P8_11_pruout_pin { pinctrl-single,pins = <
 		P8_11( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE6) >; };	/* gpmc_ad13.pru0_out15 */
+	P8_11_gpmc_pin: pinmux_P8_11_gpmc_pin { pinctrl-single,pins = <
+		P8_11( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad13.gpmc_ad13*/
 
 	/* P8_12 (ZCZ ball T12) gpio1_12 */
 	P8_12_default_pin: pinmux_P8_12_default_pin { pinctrl-single,pins = <
@@ -150,6 +168,8 @@
 		P8_12( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad12.eqep2a_in */
 	P8_12_pruout_pin: pinmux_P8_12_pruout_pin { pinctrl-single,pins = <
 		P8_12( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE6) >; };	/* gpmc_ad12.pru0_out14 */
+	P8_12_gpmc_pin: pinmux_P8_12_gpmc_pin { pinctrl-single,pins = <
+		P8_12( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad12.gpmc_ad12*/
 
 	/* P8_13 (ZCZ ball T10) gpio0_23 */
 	P8_13_default_pin: pinmux_P8_13_default_pin { pinctrl-single,pins = <
@@ -162,6 +182,8 @@
 		P8_13( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad9.gpio0_23 */
 	P8_13_pwm_pin: pinmux_P8_13_pwm_pin { pinctrl-single,pins = <
 		P8_13( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad9.ehrpwm2b */
+	P8_13_gpmc_pin: pinmux_P8_13_gpmc_pin { pinctrl-single,pins = <
+		P8_13( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad9.gpmc_ad9*/
 
 	/* P8_14 (ZCZ ball T11) gpio0_26 */
 	P8_14_default_pin: pinmux_P8_14_default_pin { pinctrl-single,pins = <
@@ -174,6 +196,8 @@
 		P8_14( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad10.gpio0_26 */
 	P8_14_pwm_pin: pinmux_P8_14_pwm_pin { pinctrl-single,pins = <
 		P8_14( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad10.ehrpwm2_tripzone_input */
+	P8_14_gpmc_pin: pinmux_P8_14_gpmc_pin { pinctrl-single,pins = <
+		P8_14( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad10.gpmc_ad10*/
 
 	/* P8_15 (ZCZ ball U13) gpio1_15 */
 	P8_15_default_pin: pinmux_P8_15_default_pin { pinctrl-single,pins = <
@@ -190,6 +214,8 @@
 		P8_15( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE5) >; };	/* gpmc_ad15.pr1_ecap0_ecap_capin_apwm_o */
 	P8_15_pruin_pin: pinmux_P8_15_pruin_pin { pinctrl-single,pins = <
 		P8_15( PIN_INPUT | MUX_MODE6) >; };			/* gpmc_ad15.pru0_in15 */
+	P8_15_gpmc_pin: pinmux_P8_15_gpmc_pin { pinctrl-single,pins = <
+		P8_15( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad15.gpmc_ad15*/
 
 	/* P8_16 (ZCZ ball V13) gpio1_14 */
 	P8_16_default_pin: pinmux_P8_16_default_pin { pinctrl-single,pins = <
@@ -204,6 +230,8 @@
 		P8_16( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad14.eqep2_index */
 	P8_16_pruin_pin: pinmux_P8_16_pruin_pin { pinctrl-single,pins = <
 		P8_16( PIN_INPUT | MUX_MODE6) >; };			/* gpmc_ad14.pru0_in14 */
+	P8_16_gpmc_pin: pinmux_P8_16_gpmc_pin { pinctrl-single,pins = <
+		P8_16( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad14.gpmc_ad14*/
 
 	/* P8_17 (ZCZ ball U12) gpio0_27 */
 	P8_17_default_pin: pinmux_P8_17_default_pin { pinctrl-single,pins = <
@@ -216,6 +244,8 @@
 		P8_17( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad11.gpio0_27 */
 	P8_17_pwm_pin: pinmux_P8_17_pwm_pin { pinctrl-single,pins = <
 		P8_17( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad11.ehrpwm0_synco */
+	P8_17_gpmc_pin: pinmux_P8_17_gpmc_pin { pinctrl-single,pins = <
+		P8_17( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad11.gpmc_ad11*/
 
 	/* P8_18 (ZCZ ball V12) gpio2_1 */
 	P8_18_default_pin: pinmux_P8_18_default_pin { pinctrl-single,pins = <
@@ -226,6 +256,8 @@
 		P8_18( PIN_OUTPUT_PULLUP | INPUT_EN | MUX_MODE7) >; };	/* gpmc_clk.gpio2_1 */
 	P8_18_gpio_pd_pin: pinmux_P8_18_gpio_pd_pin { pinctrl-single,pins = <
 		P8_18( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_clk.gpio2_1 */
+	P8_18_gpmc_pin: pinmux_P8_18_gpmc_pin { pinctrl-single,pins = <
+		P8_18( PIN_INPUT | MUX_MODE0) >; };	/* gpmc_clk.gpmc_clk*/
 
 	/* P8_18 dummy nodes for unavailable bone bus pins*/
 	P8_18_eqep_pin: pinmux_P8_18_eqep_pin { pinctrl-single,pins = <
@@ -244,6 +276,8 @@
 		P8_19( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad8.gpio0_22 */
 	P8_19_pwm_pin: pinmux_P8_19_pwm_pin { pinctrl-single,pins = <
 		P8_19( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE4) >; };	/* gpmc_ad8.ehrpwm2a */
+	P8_19_gpmc_pin: pinmux_P8_19_gpmc_pin { pinctrl-single,pins = <
+		P8_19( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad8.gpmc_ad8*/
 
 	/* P8_20 (ZCZ ball V9) emmc */
 	P8_20_default_pin: pinmux_P8_20_default_pin { pinctrl-single,pins = <
@@ -276,6 +310,8 @@
 		P8_21( PIN_INPUT | MUX_MODE6) >; };			/* gpmc_csn1.pru1_in12 */
 	P8_21_mmc_pin: pinmux_P8_21_mmc_pin { pinctrl-single,pins = <
 		P8_21( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_csn1.mmc1_clk */
+	P8_21_gpmc_pin: pinmux_P8_21_gpmc_pin { pinctrl-single,pins = <
+		P8_21( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_csn1.gpmc_csn1*/
 
 	/* P8_22 (ZCZ ball V8) emmc */
 	P8_22_default_pin: pinmux_P8_22_default_pin { pinctrl-single,pins = <
@@ -288,6 +324,8 @@
 		P8_22( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad5.gpio1_5 */
 	P8_22_mmc_pin: pinmux_P8_22_mmc_pin { pinctrl-single,pins = <
 		P8_22( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad5.mmc1_dat5 */
+	P8_22_gpmc_pin: pinmux_P8_22_gpmc_pin { pinctrl-single,pins = <
+		P8_22( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad5.gpmc_ad5*/
 
 	/* P8_23 (ZCZ ball U8) emmc */
 	P8_23_default_pin: pinmux_P8_23_default_pin { pinctrl-single,pins = <
@@ -300,6 +338,8 @@
 		P8_23( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad4.gpio1_4 */
 	P8_23_mmc_pin: pinmux_P8_23_mmc_pin { pinctrl-single,pins = <
 		P8_23( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad4.mmc1_dat4 */
+	P8_23_gpmc_pin: pinmux_P8_23_gpmc_pin { pinctrl-single,pins = <
+		P8_23( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad4.gpmc_ad4*/
 
 	/* P8_24 (ZCZ ball V7) emmc */
 	P8_24_default_pin: pinmux_P8_24_default_pin { pinctrl-single,pins = <
@@ -312,6 +352,8 @@
 		P8_24( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad1.gpio1_1 */
 	P8_24_mmc_pin: pinmux_P8_24_mmc_pin { pinctrl-single,pins = <
 		P8_24( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad1.mmc1_dat1 */
+	P8_24_gpmc_pin: pinmux_P8_24_gpmc_pin { pinctrl-single,pins = <
+		P8_24( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad1.gpmc_ad1*/
 
 	/* P8_25 (ZCZ ball U7) emmc */
 	P8_25_default_pin: pinmux_P8_25_default_pin { pinctrl-single,pins = <
@@ -324,6 +366,8 @@
 		P8_25( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_ad0.gpio1_0 */
 	P8_25_mmc_pin: pinmux_P8_25_mmc_pin { pinctrl-single,pins = <
 		P8_25( PIN_INPUT_PULLUP | MUX_MODE1) >; };	/* gpmc_ad0.mmc1_dat0 */
+	P8_25_gpmc_pin: pinmux_P8_25_gpmc_pin { pinctrl-single,pins = <
+		P8_25( PIN_INPUT_PULLUP | MUX_MODE0) >; };	/* gpmc_ad0.gpmc_ad0*/
 
 	/* P8_26 (ZCZ ball V6) gpio1_29 */
 	P8_26_default_pin: pinmux_P8_26_default_pin { pinctrl-single,pins = <
@@ -708,6 +752,8 @@
 		P9_12( PIN_OUTPUT_PULLDOWN | INPUT_EN | MUX_MODE7) >; };	/* gpmc_be1n.gpio1_28 */
 	P9_12_mcasp_pin: pinmux_P9_12_mcasp_pin { pinctrl-single,pins = <
 		P9_12( PIN_INPUT_PULLDOWN | MUX_MODE6) >; };			/* gpmc_be1n.mcasp0_aclkr */
+	P9_12_gpmc_pin: pinmux_P9_12_gpmc_pin { pinctrl-single,pins = <
+		P9_12( PIN_OUTPUT | MUX_MODE0) >; };	/* gpmc_be1n.gpmc_be1n*/
 
 	/* P9_13 (ZCZ ball U17) gpio0_31 */
 	P9_13_default_pin: pinmux_P9_13_default_pin { pinctrl-single,pins = <

--- a/src/arm/am335x-bone-common-univ.dtsi
+++ b/src/arm/am335x-bone-common-univ.dtsi
@@ -1463,149 +1463,161 @@
 	P8_03_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_03_default_pin>;
 		pinctrl-1 = <&P8_03_gpio_pin>;
 		pinctrl-2 = <&P8_03_gpio_pu_pin>;
 		pinctrl-3 = <&P8_03_gpio_pd_pin>;
+		pinctrl-4 = <&P8_03_gpmc_pin>;
 	};
 
 	/* P8_04 (ZCZ ball T9) emmc */
 	P8_04_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_04_default_pin>;
 		pinctrl-1 = <&P8_04_gpio_pin>;
 		pinctrl-2 = <&P8_04_gpio_pu_pin>;
 		pinctrl-3 = <&P8_04_gpio_pd_pin>;
+		pinctrl-4 = <&P8_04_gpmc_pin>;
 	};
 
 	/* P8_05 (ZCZ ball R8) emmc */
 	P8_05_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_05_default_pin>;
 		pinctrl-1 = <&P8_05_gpio_pin>;
 		pinctrl-2 = <&P8_05_gpio_pu_pin>;
 		pinctrl-3 = <&P8_05_gpio_pd_pin>;
+		pinctrl-4 = <&P8_05_gpmc_pin>;
 	};
 
 	/* P8_06 (ZCZ ball T8) emmc */
 	P8_06_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_06_default_pin>;
 		pinctrl-1 = <&P8_06_gpio_pin>;
 		pinctrl-2 = <&P8_06_gpio_pu_pin>;
 		pinctrl-3 = <&P8_06_gpio_pd_pin>;
+		pinctrl-4 = <&P8_06_gpmc_pin>;
 	};
 
 	/* P8_07 (ZCZ ball R7) */
 	P8_07_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer", "gpmc_pin";
 		pinctrl-0 = <&P8_07_default_pin>;
 		pinctrl-1 = <&P8_07_gpio_pin>;
 		pinctrl-2 = <&P8_07_gpio_pu_pin>;
 		pinctrl-3 = <&P8_07_gpio_pd_pin>;
 		pinctrl-4 = <&P8_07_timer_pin>;
+		pinctrl-5 = <&P8_07_gpmc_pin>;
 	};
 
 	/* P8_08 (ZCZ ball T7) */
 	P8_08_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer", "gpmc_pin";
 		pinctrl-0 = <&P8_08_default_pin>;
 		pinctrl-1 = <&P8_08_gpio_pin>;
 		pinctrl-2 = <&P8_08_gpio_pu_pin>;
 		pinctrl-3 = <&P8_08_gpio_pd_pin>;
 		pinctrl-4 = <&P8_08_timer_pin>;
+		pinctrl-5 = <&P8_08_gpmc_pin>;
 	};
 
 	/* P8_09 (ZCZ ball T6) */
 	P8_09_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer", "gpmc_pin";
 		pinctrl-0 = <&P8_09_default_pin>;
 		pinctrl-1 = <&P8_09_gpio_pin>;
 		pinctrl-2 = <&P8_09_gpio_pu_pin>;
 		pinctrl-3 = <&P8_09_gpio_pd_pin>;
 		pinctrl-4 = <&P8_09_timer_pin>;
+		pinctrl-5 = <&P8_09_gpmc_pin>;
 	};
 
 	/* P8_10 (ZCZ ball U6) */
 	P8_10_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "timer", "gpmc_pin";
 		pinctrl-0 = <&P8_10_default_pin>;
 		pinctrl-1 = <&P8_10_gpio_pin>;
 		pinctrl-2 = <&P8_10_gpio_pu_pin>;
 		pinctrl-3 = <&P8_10_gpio_pd_pin>;
 		pinctrl-4 = <&P8_10_timer_pin>;
+		pinctrl-5 = <&P8_10_gpmc_pin>;
 	};
 
 	/* P8_11 (ZCZ ball R12) */
 	P8_11_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruout";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruout", "gpmc_pin";
 		pinctrl-0 = <&P8_11_default_pin>;
 		pinctrl-1 = <&P8_11_gpio_pin>;
 		pinctrl-2 = <&P8_11_gpio_pu_pin>;
 		pinctrl-3 = <&P8_11_gpio_pd_pin>;
 		pinctrl-4 = <&P8_11_eqep_pin>;
 		pinctrl-5 = <&P8_11_pruout_pin>;
+		pinctrl-6 = <&P8_11_gpmc_pin>;
 	};
 
 	/* P8_12 (ZCZ ball T12) */
 	P8_12_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruout";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruout", "gpmc_pin";
 		pinctrl-0 = <&P8_12_default_pin>;
 		pinctrl-1 = <&P8_12_gpio_pin>;
 		pinctrl-2 = <&P8_12_gpio_pu_pin>;
 		pinctrl-3 = <&P8_12_gpio_pd_pin>;
 		pinctrl-4 = <&P8_12_eqep_pin>;
 		pinctrl-5 = <&P8_12_pruout_pin>;
+		pinctrl-6 = <&P8_12_gpmc_pin>;
 	};
 
 	/* P8_13 (ZCZ ball T10) */
 	P8_13_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "gpmc_pin";
 		pinctrl-0 = <&P8_13_default_pin>;
 		pinctrl-1 = <&P8_13_gpio_pin>;
 		pinctrl-2 = <&P8_13_gpio_pu_pin>;
 		pinctrl-3 = <&P8_13_gpio_pd_pin>;
 		pinctrl-4 = <&P8_13_pwm_pin>;
+		pinctrl-5 = <&P8_13_gpmc_pin>;
 	};
 
 	/* P8_14 (ZCZ ball T11) */
 	P8_14_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "gpmc_pin";
 		pinctrl-0 = <&P8_14_default_pin>;
 		pinctrl-1 = <&P8_14_gpio_pin>;
 		pinctrl-2 = <&P8_14_gpio_pu_pin>;
 		pinctrl-3 = <&P8_14_gpio_pd_pin>;
 		pinctrl-4 = <&P8_14_pwm_pin>;
+		pinctrl-5 = <&P8_14_gpmc_pin>;
 	};
 
 	/* P8_15 (ZCZ ball U13) */
 	P8_15_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pru_ecap_pwm", "pruin";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pru_ecap_pwm", "pruin", "gpmc_pin";
 		pinctrl-0 = <&P8_15_default_pin>;
 		pinctrl-1 = <&P8_15_gpio_pin>;
 		pinctrl-2 = <&P8_15_gpio_pu_pin>;
@@ -1613,54 +1625,59 @@
 		pinctrl-4 = <&P8_15_eqep_pin>;
 		pinctrl-5 = <&P8_15_pru_ecap_pwm_pin>;
 		pinctrl-6 = <&P8_15_pruin_pin>;
+		pinctrl-7 = <&P8_15_gpmc_pin>;
 	};
 
 	/* P8_16 (ZCZ ball V13) */
 	P8_16_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruin";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "eqep", "pruin", "gpmc_pin";
 		pinctrl-0 = <&P8_16_default_pin>;
 		pinctrl-1 = <&P8_16_gpio_pin>;
 		pinctrl-2 = <&P8_16_gpio_pu_pin>;
 		pinctrl-3 = <&P8_16_gpio_pd_pin>;
 		pinctrl-4 = <&P8_16_eqep_pin>;
 		pinctrl-5 = <&P8_16_pruin_pin>;
+		pinctrl-6 = <&P8_16_gpmc_pin>;
 	};
 
 	/* P8_17 (ZCZ ball U12) */
 	P8_17_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "gpmc_pin";
 		pinctrl-0 = <&P8_17_default_pin>;
 		pinctrl-1 = <&P8_17_gpio_pin>;
 		pinctrl-2 = <&P8_17_gpio_pu_pin>;
 		pinctrl-3 = <&P8_17_gpio_pd_pin>;
 		pinctrl-4 = <&P8_17_pwm_pin>;
+		pinctrl-5 = <&P8_17_gpmc_pin>;
 	};
 
 	/* P8_18 (ZCZ ball V12) */
 	P8_18_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_18_default_pin>;
 		pinctrl-1 = <&P8_18_gpio_pin>;
 		pinctrl-2 = <&P8_18_gpio_pu_pin>;
 		pinctrl-3 = <&P8_18_gpio_pd_pin>;
+		pinctrl-4 = <&P8_18_gpmc_pin>;
 	};
 
 	/* P8_19 (ZCZ ball U10) */
 	P8_19_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pwm", "gpmc_pin";
 		pinctrl-0 = <&P8_19_default_pin>;
 		pinctrl-1 = <&P8_19_gpio_pin>;
 		pinctrl-2 = <&P8_19_gpio_pu_pin>;
 		pinctrl-3 = <&P8_19_gpio_pd_pin>;
 		pinctrl-4 = <&P8_19_pwm_pin>;
+		pinctrl-5 = <&P8_19_gpmc_pin>;
 	};
 
 	/* P8_20 (ZCZ ball V9) emmc */
@@ -1680,57 +1697,62 @@
 	P8_21_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pruout", "pruin";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "pruout", "pruin", "gpmc_pin";
 		pinctrl-0 = <&P8_21_default_pin>;
 		pinctrl-1 = <&P8_21_gpio_pin>;
 		pinctrl-2 = <&P8_21_gpio_pu_pin>;
 		pinctrl-3 = <&P8_21_gpio_pd_pin>;
 		pinctrl-4 = <&P8_21_pruout_pin>;
 		pinctrl-5 = <&P8_21_pruin_pin>;
+		pinctrl-6 = <&P8_21_gpmc_pin>;
 	};
 
 	/* P8_22 (ZCZ ball V8) emmc */
 	P8_22_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_22_default_pin>;
 		pinctrl-1 = <&P8_22_gpio_pin>;
 		pinctrl-2 = <&P8_22_gpio_pu_pin>;
 		pinctrl-3 = <&P8_22_gpio_pd_pin>;
+		pinctrl-4 = <&P8_22_gpmc_pin>;
 	};
 
 	/* P8_23 (ZCZ ball U8) emmc */
 	P8_23_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_23_default_pin>;
 		pinctrl-1 = <&P8_23_gpio_pin>;
 		pinctrl-2 = <&P8_23_gpio_pu_pin>;
 		pinctrl-3 = <&P8_23_gpio_pd_pin>;
+		pinctrl-4 = <&P8_23_gpmc_pin>;
 	};
 
 	/* P8_24 (ZCZ ball V7) emmc */
 	P8_24_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_24_default_pin>;
 		pinctrl-1 = <&P8_24_gpio_pin>;
 		pinctrl-2 = <&P8_24_gpio_pu_pin>;
 		pinctrl-3 = <&P8_24_gpio_pd_pin>;
+		pinctrl-4 = <&P8_24_gpmc_pin>;
 	};
 
 	/* P8_25 (ZCZ ball U7) emmc */
 	P8_25_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P8_25_default_pin>;
 		pinctrl-1 = <&P8_25_gpio_pin>;
 		pinctrl-2 = <&P8_25_gpio_pu_pin>;
 		pinctrl-3 = <&P8_25_gpio_pd_pin>;
+	    pinctrl-4 = <&P8_25_gpmc_pin>;
 	};
 
 	/* P8_26 (ZCZ ball V6) */
@@ -2047,12 +2069,13 @@
 	P9_12_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pd";
 		pinctrl-0 = <&P9_12_default_pin>;
 		pinctrl-1 = <&P9_12_gpio_pin>;
 		pinctrl-2 = <&P9_12_gpio_pu_pin>;
 		pinctrl-3 = <&P9_12_gpio_pd_pin>;
 		pinctrl-4 = <&P9_12_mcasp_pin>;
+		pinctrl-5 = <&P9_12_gpmc_pin>;
 	};
 
 	/* P9_13 (ZCZ ball U17) */

--- a/src/arm/am335x-bone-common-univ.dtsi
+++ b/src/arm/am335x-bone-common-univ.dtsi
@@ -2069,7 +2069,7 @@
 	P9_12_pinmux {
 		compatible = "bone-pinmux-helper";
 		status = "okay";
-		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pd";
+		pinctrl-names = "default", "gpio", "gpio_pu", "gpio_pd", "gpmc_pin";
 		pinctrl-0 = <&P9_12_default_pin>;
 		pinctrl-1 = <&P9_12_gpio_pin>;
 		pinctrl-2 = <&P9_12_gpio_pu_pin>;

--- a/src/arm/bbb-bone-buses.dtsi
+++ b/src/arm/bbb-bone-buses.dtsi
@@ -424,6 +424,11 @@ bone_i2c_3: &i2c1 {
 	symlink = "bone/i2c/3";
 };
 
+// gpmc:
+bone_gpmc: &gpmc {
+
+};
+
 // SPIs
 bone_spi_0: &spi0 {
 

--- a/src/arm/overlays/BW-ICE40Cape-00A0.dts
+++ b/src/arm/overlays/BW-ICE40Cape-00A0.dts
@@ -1,9 +1,6 @@
 /*
- * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * Copyright (C) 2021 Omkar Bhilare <ombhilare999@gmail.com>
  * See Cape Interface Spec page for more info on Bone Buses
- * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
- *
- * Virtual cape for /dev/bone/spi/1.0
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
@@ -33,29 +30,29 @@
     P9_30_pinmux { pinctrl-0 = <&P9_29_spi_pin>; }; /* MOSI */
     P9_29_pinmux { pinctrl-0 = <&P9_30_spi_pin>; }; /* MISO */
     P9_31_pinmux { pinctrl-0 = <&P9_31_spi_sclk_pin>; }; /* CLK */
-    P8_25_pinmux { pinctrl-0 = <&pinmux_P8_25_gpmc_pin>; }; /* bw_gpmc_ad0 */
-    P8_24_pinmux { pinctrl-0 = <&pinmux_P8_24_gpmc_pin>; }; /* bw_gpmc_ad1 */
-    P8_05_pinmux { pinctrl-0 = <&pinmux_P8_05_gpmc_pin>; }; /* bw_gpmc_ad2 */
-    P8_06_pinmux { pinctrl-0 = <&pinmux_P8_06_gpmc_pin>; }; /* bw_gpmc_ad3 */
-    P8_23_pinmux { pinctrl-0 = <&pinmux_P8_23_gpmc_pin>; }; /* bw_gpmc_ad4 */
-    P8_22_pinmux { pinctrl-0 = <&pinmux_P8_22_gpmc_pin>; }; /* bw_gpmc_ad5 */
-    P8_03_pinmux { pinctrl-0 = <&pinmux_P8_03_gpmc_pin>; }; /* bw_gpmc_ad6 */
-    P8_04_pinmux { pinctrl-0 = <&pinmux_P8_04_gpmc_pin>; }; /* bw_gpmc_ad7 */
-    P8_19_pinmux { pinctrl-0 = <&pinmux_P8_19_gpmc_pin>; }; /* bw_gpmc_ad8 */
-    P8_13_pinmux { pinctrl-0 = <&pinmux_P8_13_gpmc_pin>; }; /* bw_gpmc_ad9 */
-    P8_14_pinmux { pinctrl-0 = <&pinmux_P8_14_gpmc_pin>; }; /* bw_gpmc_ad10 */
-    P8_17_pinmux { pinctrl-0 = <&pinmux_P8_17_gpmc_pin>; }; /* bw_gpmc_ad11*/
-    P8_12_pinmux { pinctrl-0 = <&pinmux_P8_12_gpmc_pin>; }; /* bw_gpmc_ad12 */
-    P8_11_pinmux { pinctrl-0 = <&pinmux_P8_11_gpmc_pin>; }; /* bw_gpmc_ad13 */
-    P8_16_pinmux { pinctrl-0 = <&pinmux_P8_16_gpmc_pin>; }; /* bw_gpmc_ad14 */
-    P8_15_pinmux { pinctrl-0 = <&pinmux_P8_15_gpmc_pin>; }; /* bw_gpmc_ad15 */
-    P8_21_pinmux { pinctrl-0 = <&pinmux_P8_21_gpmc_pin>; }; /* bw_gpmc_csn1 */
-    P8_18_pinmux { pinctrl-0 = <&pinmux_P8_18_gpmc_pin>; }; /* bw_gpmc_clk  */
-    P8_07_pinmux { pinctrl-0 = <&pinmux_P8_07_gpmc_pin>; }; /* bw_gpmc_advn_ale */
-    P8_08_pinmux { pinctrl-0 = <&pinmux_P8_08_gpmc_pin>; }; /* bw_gpmc_oen_ren */
-    P8_10_pinmux { pinctrl-0 = <&pinmux_P8_10_gpmc_pin>; }; /* bw_gpmc_wen */
-    P8_09_pinmux { pinctrl-0 = <&pinmux_P8_09_gpmc_pin>; }; /* bw_gpmc_be0n_cle*/
-    P9_12_pinmux { pinctrl-0 = <&pinmux_P9_12_gpmc_pin>; }; /* bw_gpmc_be1n */
+    P8_25_pinmux { pinctrl-0 = <&P8_25_gpmc_pin>; }; /* bw_gpmc_ad0 */
+    P8_24_pinmux { pinctrl-0 = <&P8_24_gpmc_pin>; }; /* bw_gpmc_ad1 */
+    P8_05_pinmux { pinctrl-0 = <&P8_05_gpmc_pin>; }; /* bw_gpmc_ad2 */
+    P8_06_pinmux { pinctrl-0 = <&P8_06_gpmc_pin>; }; /* bw_gpmc_ad3 */
+    P8_23_pinmux { pinctrl-0 = <&P8_23_gpmc_pin>; }; /* bw_gpmc_ad4 */
+    P8_22_pinmux { pinctrl-0 = <&P8_22_gpmc_pin>; }; /* bw_gpmc_ad5 */
+    P8_03_pinmux { pinctrl-0 = <&P8_03_gpmc_pin>; }; /* bw_gpmc_ad6 */
+    P8_04_pinmux { pinctrl-0 = <&P8_04_gpmc_pin>; }; /* bw_gpmc_ad7 */
+    P8_19_pinmux { pinctrl-0 = <&P8_19_gpmc_pin>; }; /* bw_gpmc_ad8 */
+    P8_13_pinmux { pinctrl-0 = <&P8_13_gpmc_pin>; }; /* bw_gpmc_ad9 */
+    P8_14_pinmux { pinctrl-0 = <&P8_14_gpmc_pin>; }; /* bw_gpmc_ad10 */
+    P8_17_pinmux { pinctrl-0 = <&P8_17_gpmc_pin>; }; /* bw_gpmc_ad11*/
+    P8_12_pinmux { pinctrl-0 = <&P8_12_gpmc_pin>; }; /* bw_gpmc_ad12 */
+    P8_11_pinmux { pinctrl-0 = <&P8_11_gpmc_pin>; }; /* bw_gpmc_ad13 */
+    P8_16_pinmux { pinctrl-0 = <&P8_16_gpmc_pin>; }; /* bw_gpmc_ad14 */
+    P8_15_pinmux { pinctrl-0 = <&P8_15_gpmc_pin>; }; /* bw_gpmc_ad15 */
+    P8_21_pinmux { pinctrl-0 = <&P8_21_gpmc_pin>; }; /* bw_gpmc_csn1 */
+    P8_18_pinmux { pinctrl-0 = <&P8_18_gpmc_pin>; }; /* bw_gpmc_clk  */
+    P8_07_pinmux { pinctrl-0 = <&P8_07_gpmc_pin>; }; /* bw_gpmc_advn_ale */
+    P8_08_pinmux { pinctrl-0 = <&P8_08_gpmc_pin>; }; /* bw_gpmc_oen_ren */
+    P8_10_pinmux { pinctrl-0 = <&P8_10_gpmc_pin>; }; /* bw_gpmc_wen */
+    P8_09_pinmux { pinctrl-0 = <&P8_09_gpmc_pin>; }; /* bw_gpmc_be0n_cle*/
+    P9_12_pinmux { pinctrl-0 = <&P9_12_gpmc_pin>; }; /* bw_gpmc_be1n */
 };
 
 /*

--- a/src/arm/overlays/BW-ICE40Cape-00A0.dts
+++ b/src/arm/overlays/BW-ICE40Cape-00A0.dts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2020 Deepak Khatri <deepaklorkhatri7@gmail.com>
+ * See Cape Interface Spec page for more info on Bone Buses
+ * https://elinux.org/Beagleboard:BeagleBone_cape_interface_spec
+ *
+ * Virtual cape for /dev/bone/spi/1.0
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ */
+ 
+/dts-v1/;
+/plugin/;
+
+/*
+* Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        BW-ICE40Cape-00A0 = __TIMESTAMP__;
+    };
+};
+
+/*
+ * Update the default pinmux of the pins.
+ * See these files for the phandles (&P9_* & &P8_*)
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am335x-bone-common-univ.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/am572x-bone-common-univ.dtsi
+ */
+&ocp {
+    P9_28_pinmux { pinctrl-0 = <&P9_28_spi_cs_pin>; }; /* CS */
+    P9_30_pinmux { pinctrl-0 = <&P9_29_spi_pin>; }; /* MOSI */
+    P9_29_pinmux { pinctrl-0 = <&P9_30_spi_pin>; }; /* MISO */
+    P9_31_pinmux { pinctrl-0 = <&P9_31_spi_sclk_pin>; }; /* CLK */
+    P8_25_pinmux { pinctrl-0 = <&pinmux_P8_25_gpmc_pin>; }; /* bw_gpmc_ad0 */
+    P8_24_pinmux { pinctrl-0 = <&pinmux_P8_24_gpmc_pin>; }; /* bw_gpmc_ad1 */
+    P8_05_pinmux { pinctrl-0 = <&pinmux_P8_05_gpmc_pin>; }; /* bw_gpmc_ad2 */
+    P8_06_pinmux { pinctrl-0 = <&pinmux_P8_06_gpmc_pin>; }; /* bw_gpmc_ad3 */
+    P8_23_pinmux { pinctrl-0 = <&pinmux_P8_23_gpmc_pin>; }; /* bw_gpmc_ad4 */
+    P8_22_pinmux { pinctrl-0 = <&pinmux_P8_22_gpmc_pin>; }; /* bw_gpmc_ad5 */
+    P8_03_pinmux { pinctrl-0 = <&pinmux_P8_03_gpmc_pin>; }; /* bw_gpmc_ad6 */
+    P8_04_pinmux { pinctrl-0 = <&pinmux_P8_04_gpmc_pin>; }; /* bw_gpmc_ad7 */
+    P8_19_pinmux { pinctrl-0 = <&pinmux_P8_19_gpmc_pin>; }; /* bw_gpmc_ad8 */
+    P8_13_pinmux { pinctrl-0 = <&pinmux_P8_13_gpmc_pin>; }; /* bw_gpmc_ad9 */
+    P8_14_pinmux { pinctrl-0 = <&pinmux_P8_14_gpmc_pin>; }; /* bw_gpmc_ad10 */
+    P8_17_pinmux { pinctrl-0 = <&pinmux_P8_17_gpmc_pin>; }; /* bw_gpmc_ad11*/
+    P8_12_pinmux { pinctrl-0 = <&pinmux_P8_12_gpmc_pin>; }; /* bw_gpmc_ad12 */
+    P8_11_pinmux { pinctrl-0 = <&pinmux_P8_11_gpmc_pin>; }; /* bw_gpmc_ad13 */
+    P8_16_pinmux { pinctrl-0 = <&pinmux_P8_16_gpmc_pin>; }; /* bw_gpmc_ad14 */
+    P8_15_pinmux { pinctrl-0 = <&pinmux_P8_15_gpmc_pin>; }; /* bw_gpmc_ad15 */
+    P8_21_pinmux { pinctrl-0 = <&pinmux_P8_21_gpmc_pin>; }; /* bw_gpmc_csn1 */
+    P8_18_pinmux { pinctrl-0 = <&pinmux_P8_18_gpmc_pin>; }; /* bw_gpmc_clk  */
+    P8_07_pinmux { pinctrl-0 = <&pinmux_P8_07_gpmc_pin>; }; /* bw_gpmc_advn_ale */
+    P8_08_pinmux { pinctrl-0 = <&pinmux_P8_08_gpmc_pin>; }; /* bw_gpmc_oen_ren */
+    P8_10_pinmux { pinctrl-0 = <&pinmux_P8_10_gpmc_pin>; }; /* bw_gpmc_wen */
+    P8_09_pinmux { pinctrl-0 = <&pinmux_P8_09_gpmc_pin>; }; /* bw_gpmc_be0n_cle*/
+    P9_12_pinmux { pinctrl-0 = <&pinmux_P9_12_gpmc_pin>; }; /* bw_gpmc_be1n */
+};
+
+/*
+ * See these files for the phandles (&bone_*) and other bone bus nodes
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbai-bone-buses.dtsi
+ * BeagleBoard-DeviceTrees/v4.19.x-ti-overlays/src/arm/bbb-bone-buses.dtsi
+ */
+&bone_spi_1 {
+    status = "okay";
+    #address-cells = <1>;
+    #size-cells = <0>;
+    ti,pindir-d0-out-d1-in = <1>;
+    channel@0 {
+        reg = <0>;
+        compatible = "spidev";
+        symlink = "bone/spi/1.0";
+        spi-max-frequency = <16000000>;
+        spi-cpha;
+    };
+};
+
+&bone_gpmc{
+
+    status = "okay";
+    
+    #address-cells = <2>;
+    #size-cells = <1>;
+       
+    /* chip select ranges */
+    ranges = <1 0 0x01000000 0x1000000>;
+
+    nor {
+            
+        reg = <1 0 0x01000000>;         /*CSn1*/
+        bank-width = <2>;               /* GPMC_CONFIG1_DEVICESIZE(1) */
+            
+        /*gpmc,burst-write;
+        gpmc,burst-read;
+        gpmc,burst-wrap;*/
+        gpmc,sync-read;                 /* GPMC_CONFIG1_READTYPE_ASYNC */
+        gpmc,sync-write;                /* GPMC_CONFIG1_WRITETYPE_ASYNC */
+        gpmc,clk-activation-ns = <0>;   /* GPMC_CONFIG1_CLKACTIVATIONTIME(2) */
+        gpmc,burst-length = <16>;       /* GPMC_CONFIG1_PAGE_LEN(2) */
+        gpmc,mux-add-data = <2>;        /* GPMC_CONFIG1_MUXTYPE(2) */
+
+        /* CONFIG2 */
+        gpmc,sync-clk-ps = <40000>;
+        gpmc,cs-on-ns = <0>;
+        gpmc,cs-rd-off-ns = <200>;
+        gpmc,cs-wr-off-ns = <200>;
+
+        /* CONFIG3 */
+        gpmc,adv-on-ns = <0>;
+        gpmc,adv-rd-off-ns = <80>;
+        gpmc,adv-wr-off-ns = <80>;
+
+        /* CONFIG4 */
+        gpmc,we-on-ns = <40>;
+        gpmc,we-off-ns = <200>;
+        gpmc,oe-on-ns = <40>;
+        gpmc,oe-off-ns = <200>;
+
+        /* CONFIG 5 */
+        gpmc,page-burst-access-ns = <40>;
+        gpmc,access-ns = <200>;
+        gpmc,rd-cycle-ns = <280>;
+        gpmc,wr-cycle-ns = <280>;
+
+        /* CONFIG 6 */
+        gpmc,wr-access-ns = <40>;
+        gpmc,wr-data-mux-bus-ns = <40>;
+        /*gpmc,bus-turnaround-ns = <40>;*/  /* CONFIG6:3:0 = 4 */
+        /*gpmc,cycle2cycle-samecsen;*/      /* CONFIG6:7 = 1 */
+        /*gpmc,cycle2cycle-delay-ns = <40>;*/   /* CONFIG6:11:8 = 4 */
+    };
+};

--- a/src/arm/overlays/BW-ICE40Cape-00A0_LKM.dts
+++ b/src/arm/overlays/BW-ICE40Cape-00A0_LKM.dts
@@ -1,0 +1,177 @@
+/*
+* Copyright (C) 2018 Patryk Mezydlo <mezydlo.p@gmail.com>
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License version 2 as
+* published by the Free Software Foundation.
+*/
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "ti,beaglebone", "ti,beaglebone-black";
+	part-number = "BW-ICE40Cape";
+	version = "00A0";
+
+	/* state the resources this cape uses */
+	exclusive-use =
+		/* the pin header uses */
+		"P9.31",	/* bw_spi1_sclk */
+		"P9.29",	/* bw_spi1_d0 */
+		"P9.30",	/* bw_spi1_d1 */
+		"P9.28",	/* bw_spi1_cs0 */
+		"P9.25",	/* bw_creset */
+		"P9.21",	/* bw_cdone */
+		"P8.25",	/* bw_gpmc_ad0 */
+		"P8.24",	/* bw_gpmc_ad1 */
+		"P8.5",		/* bw_gpmc_ad2 */
+		"P8.6",		/* bw_gpmc_ad3 */
+		"P8.23",	/* bw_gpmc_ad4 */
+		"P8.22",	/* bw_gpmc_ad5 */
+		"P8.3",		/* bw_gpmc_ad6 */
+		"P8.4",		/* bw_gpmc_ad7 */
+		"P8.19",	/* bw_gpmc_ad8 */
+		"P8.13",	/* bw_gpmc_ad9 */
+		"P8.14",	/* bw_gpmc_ad10 */
+		"P8.17",	/* bw_gpmc_ad11 */
+		"P8.12",	/* bw_gpmc_ad12 */
+		"P8.11",	/* bw_gpmc_ad13 */
+		"P8.16",	/* bw_gpmc_ad14 */
+		"P8.15",	/* bw_gpmc_ad15 */
+		"P9.12",	/* bw_gpmc_ben1 */
+		"P8.21",	/* bw_gpmc_csn1 */
+		"P8.18",	/* bw_gpmc_clk */
+		"P8.7",		/* bw_gpmc_advn_ale */
+		"P8.8",		/* bw_gpmc_oen_ren */
+		"P8.10",	/* bw_gpmc_wen */
+		"P8.9",		/* bw_gpmc_ben0_cle */
+		"gpmc",
+		"spi1";
+
+	fragment@0 {
+		target = <&am33xx_pinmux>;
+		__overlay__ {
+			bw_spi1_pins: pinmux_bw_spi1_pins {
+				pinctrl-single,pins = <
+					0x190 0x33	/* mcasp0_aclkx.spi1_sclk, INPUT_PULLUP | MODE3 */
+					0x194 0x33	/* mcasp0_fsx.spi1_d0, INPUT_PULLUP | MODE3 */
+					0x198 0x13	/* mcasp0_axr0.spi1_d1, OUTPUT_PULLUP | MODE3 */
+					0x19c 0x13	/* mcasp0_ahclkr.spi1_cs0, OUTPUT_PULLUP | MODE3 */
+					0x1ac 0x07	/* CRESET GPIO OUTPUT | MODE7 */
+					0x154 0x27	/* CDONE GPIO INPUT | MODE7 */
+				>;
+			};
+
+			bw_gpmc_pins: pinmux_bw_gpmc_pins {
+				pinctrl-single,pins = <
+					0x000 0x30	/* gpmc_ad0.gpmc_ad0 MODE0 | INPUT | PULLUP */
+					0x004 0x30	/* gpmc_ad1.gpmc_ad1 MODE0 | INPUT | PULLUP */
+					0x008 0x30	/* gpmc_ad2.gpmc_ad2 MODE0 | INPUT | PULLUP */
+					0x00C 0x30	/* gpmc_ad3.gpmc_ad3 MODE0 | INPUT | PULLUP */
+					0x010 0x30	/* gpmc_ad4.gpmc_ad4 MODE0 | INPUT | PULLUP */
+					0x014 0x30	/* gpmc_ad5.gpmc_ad5 MODE0 | INPUT | PULLUP */
+					0x018 0x30	/* gpmc_ad6.gpmc_ad6 MODE0 | INPUT | PULLUP */
+					0x01C 0x30	/* gpmc_ad7.gpmc_ad7 MODE0 | INPUT | PULLUP */
+					0x020 0x30	/* gpmc_ad8.gpmc_ad8 MODE0 | INPUT | PULLUP */
+					0x024 0x30	/* gpmc_ad9.gpmc_ad9 MODE0 | INPUT | PULLUP */
+					0x028 0x30	/* gpmc_ad10.gpmc_ad10 MODE0 | INPUT | PULLUP */
+					0x02C 0x30	/* gpmc_ad11.gpmc_ad11 MODE0 | INPUT | PULLUP */
+					0x030 0x30	/* gpmc_ad12.gpmc_ad12 MODE0 | INPUT | PULLUP */
+					0x034 0x30	/* gpmc_ad13.gpmc_ad13 MODE0 | INPUT | PULLUP */
+					0x038 0x30	/* gpmc_ad14.gpmc_ad14 MODE0 | INPUT | PULLUP */
+					0x03C 0x30	/* gpmc_ad15.gpmc_ad15 MODE0 | INPUT | PULLUP */
+					0x080 0x08	/* gpmc_cscn1.gpmc_cscn1 MODE0 | OUTPUT */
+					0x08C 0x28	/* gpmc_clk.gpmc_clk MODE0 | INPUT */
+					0x090 0x08	/* gpmc_advn_ale.gpmc_advn_ale MODE0 | OUTPUT */
+					0x094 0x08	/* gpmc_oen_ren.gpmc_oen_ren MODE0 | OUTPUT */
+					0x098 0x08	/* gpmc_wen.gpmc_wen MODE0 | OUTPUT */
+					0x09C 0x08	/* gpmc_ben0_cle.gpmc_ben0_cle MODE0 | OUTPUT */
+					0x078 0x08	/* gpmc_ben1_cle.gpmc_ben1_cle MODE0 | OUTPUT */
+				>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&spi1>;
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&bw_spi1_pins>;
+
+			ice40: fpga@0 {
+				compatible = "lattice,ice40-fpga-mgr";
+				reg = <0>;
+				spi-max-frequency = <10000000>;
+				cdone-gpios = <&gpio0 3 0>;
+				reset-gpios = <&gpio3 21 1>;
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&gpmc>;
+		depth = <1>;	/* only create devices on depth 1 */
+
+		/* stupid warnings */
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		__overlay__ {
+
+			status = "okay";
+
+			#address-cells = <2>;
+			#size-cells = <1>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&bw_gpmc_pins>;
+
+			/* chip select ranges */
+			ranges = <1 0 0x01000000 0x1000000>;
+
+			nor {
+				reg = <1 0 0x01000000>;			/*CSn1*/
+				bank-width = <2>;			/* GPMC_CONFIG1_DEVICESIZE(1) */
+				/*gpmc,burst-write;
+				gpmc,burst-read;
+				gpmc,burst-wrap;*/
+				gpmc,sync-read;				/* GPMC_CONFIG1_READTYPE_ASYNC */
+				gpmc,sync-write;			/* GPMC_CONFIG1_WRITETYPE_ASYNC */
+				gpmc,clk-activation-ns = <0>;		/* GPMC_CONFIG1_CLKACTIVATIONTIME(2) */
+				gpmc,burst-length = <16>;		/* GPMC_CONFIG1_PAGE_LEN(2) */
+				gpmc,mux-add-data = <2>;		/* GPMC_CONFIG1_MUXTYPE(2) */
+
+				/* CONFIG2 */
+				gpmc,sync-clk-ps = <40000>;
+				gpmc,cs-on-ns = <0>;
+				gpmc,cs-rd-off-ns = <200>;
+				gpmc,cs-wr-off-ns = <200>;
+
+				/* CONFIG3 */
+				gpmc,adv-on-ns = <0>;
+				gpmc,adv-rd-off-ns = <80>;
+				gpmc,adv-wr-off-ns = <80>;
+
+				/* CONFIG4 */
+				gpmc,we-on-ns = <40>;
+				gpmc,we-off-ns = <200>;
+				gpmc,oe-on-ns = <40>;
+				gpmc,oe-off-ns = <200>;
+
+				/* CONFIG 5 */
+				gpmc,page-burst-access-ns = <40>;
+				gpmc,access-ns = <200>;
+				gpmc,rd-cycle-ns = <280>;
+				gpmc,wr-cycle-ns = <280>;
+
+				/* CONFIG 6 */
+				gpmc,wr-access-ns = <40>;
+				gpmc,wr-data-mux-bus-ns = <40>;
+				/*gpmc,bus-turnaround-ns = <40>;*/	/* CONFIG6:3:0 = 4 */
+				/*gpmc,cycle2cycle-samecsen;*/		/* CONFIG6:7 = 1 */
+				/*gpmc,cycle2cycle-delay-ns = <40>;*/	/* CONFIG6:11:8 = 4 */
+			};
+		};
+	};
+};

--- a/src/arm/overlays/Makefile
+++ b/src/arm/overlays/Makefile
@@ -63,7 +63,8 @@ dtbo-$(CONFIG_ARCH_OMAP2PLUS) += \
 	BONE-UART3.dtbo \
 	BONE-UART4.dtbo \
 	BONE-UART5.dtbo \
-	BW-ICE40Cape-00A0.dtbo 
+	BW-ICE40Cape-00A0.dtbo \
+	BW-ICE40Cape-00A0_LKM.dtbo
 	
 targets += dtbs dtbs_install
 targets += $(dtbo-y)

--- a/src/arm/overlays/Makefile
+++ b/src/arm/overlays/Makefile
@@ -62,8 +62,9 @@ dtbo-$(CONFIG_ARCH_OMAP2PLUS) += \
 	BONE-UART2.dtbo \
 	BONE-UART3.dtbo \
 	BONE-UART4.dtbo \
-	BONE-UART5.dtbo
-
+	BONE-UART5.dtbo \
+	BW-ICE40Cape-00A0.dtbo 
+	
 targets += dtbs dtbs_install
 targets += $(dtbo-y)
 


### PR DESCRIPTION
Earlier it was not possible to use `config-pin` utility with `GPMC` as there were no defined gpmc modes in pinux of bone common file, So I tried adding them after discussion with @lorforlinux. I got everything worked now.

1) For all the pins I had added `gpmc_pin` mode here:
  https://github.com/BeagleWire/BeagleBoard-DeviceTrees/blob/a7bd4fd23d56003146fcd426f52a7b627abcc512/src/arm/am335x-bone-common-univ.dtsi#L199-L200
2) Afterwards Also added the same pin mode in pinmux to show on `config-pin` side:
  https://github.com/BeagleWire/BeagleBoard-DeviceTrees/blob/a7bd4fd23d56003146fcd426f52a7b627abcc512/src/arm/am335x-bone-common-univ.dtsi#L1603-L1614
3) I have also added phandle for gpmc too in bone bus file:
  https://github.com/BeagleWire/BeagleBoard-DeviceTrees/blob/a7bd4fd23d56003146fcd426f52a7b627abcc512/src/arm/bbb-bone-buses.dtsi#L427-L430
4) Finally added the BeagleWire overlay too in `src/arn/overlays`:
- [BW-ICE40Cape-00A0.dts](https://github.com/BeagleWire/BeagleBoard-DeviceTrees/blob/a7bd4fd23d56003146fcd426f52a7b627abcc512/src/arm/overlays/BW-ICE40Cape-00A0.dts)  
 - [BW-ICE40Cape-00A0_LKM.dts](https://github.com/BeagleWire/BeagleBoard-DeviceTrees/blob/a7bd4fd23d56003146fcd426f52a7b627abcc512/src/arm/overlays/BW-ICE40Cape-00A0_LKM.dts)  
 
 Demo of working video:
 https://asciinema.org/a/ICSlldHwYC4RtOHG0oJkIRUBd
 
regards,
Omkar Bhilare
ombhilare999@gmail.com