### PR TITLE
bbai64: fixups for pcie m.2 internal clock source + leds

### DIFF
--- a/src/arm64/k3-j721e-beagleboneai.dts
+++ b/src/arm64/k3-j721e-beagleboneai.dts
@@ -361,8 +361,6 @@
 			J721E_IOPAD(0x10c, PIN_INPUT, 7) /* (AC25) PRG0_PRU1_GPO3.GPIO0_66 */
 			J721E_IOPAD(0x140, PIN_INPUT, 7) /* (AG29) PRG0_PRU1_GPO16.GPIO0_79 */
 			J721E_IOPAD(0x144, PIN_INPUT, 7) /* (Y25) PRG0_PRU1_GPO17.GPIO0_80 */
-
-			J721E_IOPAD(0x5c, PIN_INPUT, 7) /* (AG23) PRG1_PRU1_GPO1.GPIO0_22 */
 		>;
 	};
 
@@ -934,7 +932,6 @@
 };
 
 &pcie1_rc {
-	reset-gpios = <&main_gpio0 22 GPIO_ACTIVE_HIGH>;
 	phys = <&serdes1_pcie_link>;
 	phy-names = "pcie-phy";
 	num-lanes = <2>;

--- a/src/arm64/k3-j721e-beagleboneai.dts
+++ b/src/arm64/k3-j721e-beagleboneai.dts
@@ -420,6 +420,12 @@
 			J721E_IOPAD(0x4c, PIN_INPUT, 7) /* (AJ21) PRG1_PRU0_GPO17.GPIO0_18 */
 		>;
 	};
+
+	pcie1_rst_pins_default: pcie1-rst-pins-default {
+		pinctrl-single,pins = <
+			J721E_IOPAD(0x5c, PIN_INPUT, 7) /* (AG23) PRG1_PRU1_GPO1.GPIO0_22 */
+		>;
+	};
 };
 
 &wkup_pmx0 {
@@ -898,9 +904,12 @@
 };
 
 &pcie1_rc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie1_rst_pins_default>;
 	phys = <&serdes1_pcie_link>;
 	phy-names = "pcie-phy";
 	num-lanes = <2>;
+	reset-gpios = <&main_gpio0 22 GPIO_ACTIVE_HIGH>;
 };
 
 &pcie2_rc {

--- a/src/arm64/k3-j721e-beagleboneai.dts
+++ b/src/arm64/k3-j721e-beagleboneai.dts
@@ -57,13 +57,13 @@
 
 		usr_led3: usr_led3 {
 			label = "usr_led3";
-			linux,default-trigger = "default-off";
+			linux,default-trigger = "panic-indicator";
 			gpios = <&main_gpio0 110 GPIO_ACTIVE_HIGH>;
 		};
 
 		usr_led4: usr_led4 {
 			label = "usr_led4";
-			linux,default-trigger = "default-off";
+			linux,default-trigger = "heartbeat";
 			gpios = <&main_gpio0 109 GPIO_ACTIVE_HIGH>;
 		};
 	};

--- a/src/arm64/k3-j721e-beagleboneai.dts
+++ b/src/arm64/k3-j721e-beagleboneai.dts
@@ -863,40 +863,6 @@
 	status = "disabled";
 };
 
-&cmn_refclk1 {
-	clock-frequency = <100000000>;
-};
-
-&wiz0_pll1_refclk {
-	assigned-clocks = <&wiz0_pll1_refclk>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
-&wiz0_refclk_dig {
-	assigned-clocks = <&wiz0_refclk_dig>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
-&wiz1_pll1_refclk {
-	assigned-clocks = <&wiz1_pll1_refclk>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
-&wiz1_refclk_dig {
-	assigned-clocks = <&wiz1_refclk_dig>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
-&wiz2_pll1_refclk {
-	assigned-clocks = <&wiz2_pll1_refclk>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
-&wiz2_refclk_dig {
-	assigned-clocks = <&wiz2_refclk_dig>;
-	assigned-clock-parents = <&cmn_refclk1>;
-};
-
 &serdes0 {
 	serdes0_pcie_link: phy@0 {
 		reg = <0>;


### PR DESCRIPTION
Fixups include:
- gpio reset for PCIe
- we should'nt be telling serdes clock mux to mux external clock when we are trying to use internal clock
- lets have some led blinky that tells us the system is alive and not dead.

Test log: https://gist.github.com/nmenon/679e9843f0d5f1bbb50e24f150e0235c