### PR TITLE
arm64: dts: ti: k3-j721e-beagleboneai: Set the model name correct

### DIFF
--- a/src/arm64/k3-j721e-beagleboneai.dts
+++ b/src/arm64/k3-j721e-beagleboneai.dts
@@ -11,6 +11,10 @@
 #include <dt-bindings/net/ti-dp83867.h>
 
 / {
+
+	model = "BeagleBoard.org BeagleBone AI64";
+	compatible = "beagle,j721e-beagleboneai64", "ti,j721e";
+
 	chosen {
 		stdout-path = "serial2:115200n8";
 		bootargs = "console=ttyS2,115200n8 earlycon=ns16550a,mmio32,0x02800000";


### PR DESCRIPTION
Lets make sure the logs and compatibles make sense

Signed-off-by: Nishanth Menon <nm@ti.com>