### PR TITLE
am335x-sancloud-bbe-lite-uboot-univ: Disable header pins used for spi0

### DIFF
--- a/src/arm/am335x-sancloud-bbe-lite-uboot-univ.dts
+++ b/src/arm/am335x-sancloud-bbe-lite-uboot-univ.dts
@@ -136,3 +136,21 @@
 		spi-cpha;
 	};
 };
+
+&ocp {
+	P9_17_pinmux {
+		status = "disabled";
+	};
+
+	P9_18_pinmux {
+		status = "disabled";
+	};
+
+	P9_21_pinmux {
+		status = "disabled";
+	};
+
+	P9_22_pinmux {
+		status = "disabled";
+	};
+};


### PR DESCRIPTION
The BBE Lite has an Authenta SPI flash device fitted on the spi0 bus.
Disable the configurable header pins which overlap with those used for
spi0 to prevent errors during boot.

This fixes errors such as the following seen during boot:

```
[   11.087932] pinctrl-single 44e10800.pinmux: pin PIN84 already requested by ocp:P9_22_pinmux; cannot claim for 48030000.spi
[   11.099253] pinctrl-single 44e10800.pinmux: pin-84 (48030000.spi) status -22
[   11.106389] pinctrl-single 44e10800.pinmux: could not request pin 84 (PIN84) from group pinmux_bb_spi0_pins  on device pinctrl-single
[   11.118468] omap2_mcspi 48030000.spi: Error applying setting, reverse things back
[   11.126095] omap2_mcspi: probe of 48030000.spi failed with error -22
```