### PR TITLE
overlays: Update mikroBUS overlay to remote GPIO CS

### DIFF
--- a/src/arm/overlays/PB-MIKROBUS-0.dts
+++ b/src/arm/overlays/PB-MIKROBUS-0.dts
@@ -98,7 +98,6 @@
 
 &spi0 {
 	status = "okay";
-	cs-gpios = <0>, <&gpio2 25 GPIO_ACTIVE_HIGH>;
 	channel@0{ status = "disabled"; };
 };
 

--- a/src/arm/overlays/PB-MIKROBUS-1.dts
+++ b/src/arm/overlays/PB-MIKROBUS-1.dts
@@ -98,7 +98,6 @@
 
 &spi1 {
 	status = "okay";
-	cs-gpios = <0>, <0>, <&gpio1 13 GPIO_ACTIVE_HIGH>;
 	channel@0{ status = "disabled"; };
 	channel@1{ status = "disabled"; };
 };


### PR DESCRIPTION
mikroe plans to update the clicks with SPI Chip Select on
RST line(usually used when there is more than one device
on click Eg: Waveform Click), currently RST line is planned
to be used specifically for Enter ID mode, RST GPIO