### PR TITLE
am335x: Correct GPIO0_7 pin name, is conneted to P9_42, not P8

### DIFF
--- a/src/arm/am335x-boneblack-uboot-univ.dts
+++ b/src/arm/am335x-boneblack-uboot-univ.dts
@@ -54,7 +54,7 @@
 		"P9_18 [spi0_d1]",
 		"P9_17 [spi0_cs0]",
 		"[mmc0_cd]",
-		"P8_42A [ecappwm0]",
+		"P9_42A [ecappwm0]",
 		"P8_35 [lcd d12]",
 		"P8_33 [lcd d13]",
 		"P8_31 [lcd d14]",

--- a/src/arm/am335x-boneblack-uboot.dts
+++ b/src/arm/am335x-boneblack-uboot.dts
@@ -57,7 +57,7 @@
 		"P9_18 [spi0_d1]",
 		"P9_17 [spi0_cs0]",
 		"[mmc0_cd]",
-		"P8_42A [ecappwm0]",
+		"P9_42A [ecappwm0]",
 		"P8_35 [lcd d12]",
 		"P8_33 [lcd d13]",
 		"P8_31 [lcd d14]",


### PR DESCRIPTION
Note: Same as in fix: gpioline: P9_42A [ecappwm0]