### PR TITLE
V6.12.x beagle Added overlays for MCSPI1,2,3,6 and 7 for the BBAI64

### DIFF
--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI1 pins P8_35b(cs0), P9_26a(clk), P9_24a(MOSI).
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/* 
+ * WARNING!!!
+ * This overlay will not mux if there are pin conflicts. For example, by default i2c4 is enabled taking
+ * pins P9_24 and P9_26. To stop pin conflicts, this overlay disables i2c4.
+ *
+ * Look for errors in `sudo beagle-version \| grep UBOOT`
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi1-cs0.kernel = __TIMESTAMP__;
+                mcspi1.2130000.spi = "k3-j721e-beagleboneai64-spi-mcspi1-cs0.2130000";
+        };
+};
+
+/* Disable i2c4 to free up pins p9_24 and p9_26 */
+&main_i2c4 {
+        status = "disable";
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+*/
+&main_pmx0 {
+    mcspi1_cs_zero: mcspi1-cs0-pins {
+        pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+			J721E_IOPAD(0x1dc, PIN_OUTPUT, 0) /* (Y1) SPI1_CLK P9_26a*/
+			J721E_IOPAD(0x1d4, PIN_OUTPUT, 0) /* (Y3) SPI1_CS0 P8_35b*/
+			J721E_IOPAD(0x1e0, PIN_OUTPUT, 0) /* (Y5) SPI1_D0 P9_24a*/
+            /* J721E_IOPAD(0x1e4, PIN_INPUT, 0) (Y2) SPI1_D1 P9_18b......Conflicts with SPI6_D1*/
+
+            /* Disable SoC pins that share same BB header pins */
+            J721E_IOPAD(0x30, PIN_DISABLE, 7) /* (AF24) disable P9_26b */
+            J721E_IOPAD(0x34, PIN_DISABLE, 7) /* (AJ24) disable P9_24b */
+            /* J721E_IOPAD(0xA4, PIN_DISABLE, 7) (0xA4) disable P9_18a .... for if we are using P9_18b */
+        >;
+    };
+};
+
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
+ */
+&main_spi3 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi1_cs_zero>;
+    ti,spi-num-cs = <1>; /* With this number wrong, no spi device would get created, error seen with `sudo journalctl -k` */
+    ti,pindir-d0-out-d1-in; /* d1 is not really an input, the pin is not muxed */
+    status = "okay";
+
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/1.0"; /* /dev/bone/spi/1.0 */
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
@@ -26,7 +26,7 @@
 &{/chosen} {
         overlays {
                 k3-j721e-beagleboneai64-spi-mcspi1-cs0.kernel = __TIMESTAMP__;
-                mcspi1.2130000.spi = "k3-j721e-beagleboneai64-spi-mcspi1-cs0.2130000";
+                mcspi1.2110000.spi = "k3-j721e-beagleboneai64-spi-mcspi1-cs0.2110000";
         };
 };
 

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
@@ -66,7 +66,7 @@
  *
  * Make sure to load the spidev driver to control SPI from linux.
  */
-&main_spi3 {
+&main_spi1 {
     #address-cells = <1>;
     #size-cells = <0>;
     pinctrl-names = "default";

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
@@ -54,6 +54,7 @@
 
             /* Disable SoC pins that share same BB header pins */
             J721E_IOPAD(0x30, PIN_DISABLE, 7) /* (AF24) disable P9_26b */
+            J721E_IOPAD(0x64, PIN_DISABLE, 7) /* (AD23) disable P8_35a  */
             J721E_IOPAD(0x34, PIN_DISABLE, 7) /* (AJ24) disable P9_24b */
             /* J721E_IOPAD(0xA4, PIN_DISABLE, 7) (0xA4) disable P9_18a .... for if we are using P9_18b */
         >;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0-no-miso.dtso
@@ -78,7 +78,7 @@
 
     /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@0 {
-        symlink = "bone/spi/1.0"; /* /dev/bone/spi/1.0 */
+        symlink = "bone/spi/1.0_no_miso"; /* /dev/bone/spi/1.0_no_miso */
         compatible = "rohm,dh2228fv";
         reg = <0>; /* CE0 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi1-cs0.dtso
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI1 pins P8_35b(cs0), P9_26a(clk), P9_24a(MOSI).
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/* 
+ * WARNING!!!
+ * This overlay will not mux if there are pin conflicts. For example, by default i2c4 is enabled taking
+ * pins P9_24 and P9_26. To stop pin conflicts, this overlay disables i2c4 and i2c6. This overlay
+ * also conflicts with SPI6_D1, the miso for spi6
+ *
+ * Look for errors in `sudo beagle-version \| grep UBOOT`
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi1-cs0.kernel = __TIMESTAMP__;
+                mcspi1.2110000.spi = "k3-j721e-beagleboneai64-spi-mcspi1-cs0.2110000";
+        };
+};
+
+/* Disable i2c4 to free up pins p9_24 and p9_26 */
+&main_i2c4 {
+        status = "disable";
+};
+
+/* Disable i2c6 to free up pin p9_18 */
+&main_i2c6 {
+        status = "disable";
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+*/
+&main_pmx0 {
+    mcspi1_cs_zero: mcspi1-cs0-pins {
+        pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+			J721E_IOPAD(0x1dc, PIN_OUTPUT, 0) /* (Y1) SPI1_CLK P9_26a*/
+			J721E_IOPAD(0x1d4, PIN_OUTPUT, 0) /* (Y3) SPI1_CS0 P8_35b*/
+			J721E_IOPAD(0x1e0, PIN_OUTPUT, 0) /* (Y5) SPI1_D0 P9_24a*/
+            J721E_IOPAD(0x1e4, PIN_INPUT, 0)  /* (Y2) SPI1_D1 P9_18b......Conflicts with SPI6_D1*/
+
+            /* Disable SoC pins that share same BB header pins */
+            J721E_IOPAD(0x30, PIN_DISABLE, 7) /* (AF24) disable P9_26b */
+            J721E_IOPAD(0x64, PIN_DISABLE, 7) /* (AD23) disable P835a  */
+            J721E_IOPAD(0x34, PIN_DISABLE, 7) /* (AJ24) disable P9_24b */
+            J721E_IOPAD(0xA4, PIN_DISABLE, 7) /* (AH22) disable P9_18a */
+        >;
+    };
+};
+
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
+ */
+&main_spi1 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi1_cs_zero>;
+    ti,spi-num-cs = <1>; /* With this number wrong, no spi device would get created, error seen with `sudo journalctl -k` */
+    ti,pindir-d0-out-d1-in; /* d1 is not really an input, the pin is not muxed */
+    status = "okay";
+
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/1.0"; /* /dev/bone/spi/1.0 */
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi2-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi2-cs0.dtso
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI6 pins P9_17(cs0), P9_22(clk), P9_21(MOSI), P9_18(MISO).
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/* 
+ * WARNING!!!
+ * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
+ * pins P9_17 and P9_18. To stop pin conflicts, this overlay disables i2c6.
+ *
+ * Look for errors in `sudo beagle-version \| grep UBOOT`
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi2-cs0.kernel = __TIMESTAMP__;
+                mcspi2.2120000.spi = "k3-j721e-beagleboneai64-spi-mcspi2-cs0.2120000";
+        };
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+*/
+&main_pmx0 {
+    mcspi2_cs_zero: mcspi2-cs0-pins {
+        pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+            J721E_IOPAD(0x1f4, PIN_OUTPUT, 4) /* (AB1) UART0_RTSn.SPI2_CLK */
+            J721E_IOPAD(0x1f0, PIN_OUTPUT, 4) /* (AC2) UART0_CTSn.SPI2_CS0 */
+            J721E_IOPAD(0x200, PIN_OUTPUT, 4) /* (AC4) UART1_CTSn.SPI2_D0 */
+            J721E_IOPAD(0x204, PIN_INPUT, 4) /* (AD5) UART1_RTSn.SPI2_D1 */
+
+            /* Disable SoC pins that share same BB header pins */
+            /* This pin conflics*/
+            J721E_IOPAD(0xbc, PIN_DISABLE, 7) /* (AD26) disable P9_27a */
+            J721E_IOPAD(0x4c, PIN_DISABLE, 7) /* (AJ21) disable P9_42b */
+            J721E_IOPAD(0x1A4, PIN_DISABLE, 7) /* (W26) disable P9_25b */
+        >;
+    };
+};
+
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
+ */
+&main_spi2 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi2_cs_zero>;
+    ti,spi-num-cs = <1>;
+    ti,pindir-d0-out-d1-in;
+    status = "okay";
+
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/2.0"; /* /dev/bone/spi/2.0 */
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI6 pins P8_40(cs0), P8_46(clk), P9_40b(MOSI).
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi3-cs0.kernel = __TIMESTAMP__;
+                mcspi3.2130000.spi = "k3-j721e-beagleboneai64-spi-mcspi3-cs0.2130000";
+        };
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+*/
+&main_pmx0 {
+    mcspi3_cs_one: mcspi3-cs0-pins {
+        pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+            J721E_IOPAD(0x144, PIN_OUTPUT, 4) /* (Y25) PRG0_PRU1_GPO17.SPI3_CLK P8_46 */
+            J721E_IOPAD(0x11c, PIN_OUTPUT, 4) /* (AA24) PRG0_PRU1_GPO7.SPI3_CS0 P8_40*/
+            J721E_IOPAD(0x148, PIN_OUTPUT, 4) /* (AA26) PRG0_PRU1_GPO18.SPI3_D0 P9_40b*/
+
+            /* Disable SoC pins that share same BB header pins */
+            /* Using the J721E_WKUP_IOPAD() marco because K26, as seen from spreadsheet above, is a MCU/WKUP pin */
+            J721E_WKUP_IOPAD(0x134, PIN_DISABLE, 7) /* (K26) MCU_ADC0_AIN1 K26_AA26 disable P9_40a */
+        >;
+    };
+};
+
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
+ */
+&main_spi3 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi3_cs_one>;
+    ti,spi-num-cs = <1>; /* With this number wrong, no spi device would get created, error seen with `sudo journalctl -k` */
+    ti,pindir-d0-out-d1-in; /* d1 is not really an input, the pin is not muxed */
+    status = "okay";
+
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/3.0"; /* /dev/bone/spi/3.0 */
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
@@ -62,7 +62,7 @@
 
     /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@0 {
-        symlink = "bone/spi/3.0"; /* /dev/bone/spi/3.0 */
+        symlink = "bone/spi/3.0_no_miso"; /* /dev/bone/spi/3.0_no_miso */
         compatible = "rohm,dh2228fv";
         reg = <0>; /* CE0 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi3-cs0-no-miso.dtso
@@ -31,7 +31,7 @@
  *
 */
 &main_pmx0 {
-    mcspi3_cs_one: mcspi3-cs0-pins {
+    mcspi3_cs_zero: mcspi3-cs0-pins {
         pinctrl-single,pins = <            
             /* Used TI SysConfig app to generate these, had manually adjust output modes */
             J721E_IOPAD(0x144, PIN_OUTPUT, 4) /* (Y25) PRG0_PRU1_GPO17.SPI3_CLK P8_46 */
@@ -55,7 +55,7 @@
     #address-cells = <1>;
     #size-cells = <0>;
     pinctrl-names = "default";
-    pinctrl-0 = <&mcspi3_cs_one>;
+    pinctrl-0 = <&mcspi3_cs_zero>;
     ti,spi-num-cs = <1>; /* With this number wrong, no spi device would get created, error seen with `sudo journalctl -k` */
     ti,pindir-d0-out-d1-in; /* d1 is not really an input, the pin is not muxed */
     status = "okay";

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI6 CS0 and CS1 on the BeagleBoneAI64.
+ * Pins:
+ * - CS0: P9_17a (SPI6_CS0)
+ * - CS1: P9_23 (SPI6_CS1)
+ * - CLK: P9_22a (SPI6_CLK)
+ * - MOSI: P9_21a (SPI6_D0)
+ * - MISO: P9_18a (SPI6_D1)
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+    overlays {
+        k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.kernel = __TIMESTAMP__;
+        mcspi6.2160000.spi = "k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.2160000";
+    };
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+ *
+ * ~~ Walkthrough of process to figure out muxing ~~
+ *
+ * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
+ * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
+ * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
+ * 
+ * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
+ * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
+ * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
+ * 
+ * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
+ * pad U29. Using the same process as walked through with pad AC22, you get the following:
+ * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
+ *
+ * So to mux SPI6_CLK on BB pin P9_22:
+ * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
+ * J721E_IOPAD(0x170, PIN_DISABLE, 7)
+ *
+*/
+&main_pmx0 {
+	mcspi6_pins: mcspi6-pins {
+		pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+            J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
+			J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
+			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
+			J721E_IOPAD(0xa4, PIN_INPUT, 4) /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
+            /* J721E_IOPAD(0x28, PIN_OUTPUT, 4) */ /* (AG20) PRG1_PRU1_GPO8.SPI6_CS1 P9_23 */
+
+            /* Disable SoC pins that share same BB header pins */
+            /* These pins conflict */
+            J721E_IOPAD(0x170, PIN_DISABLE, 7) /* (U29) disable P9_22b */
+            J721E_IOPAD(0x1D0, PIN_DISABLE, 7) /* (AA3) disable P9_17b */
+            J721E_IOPAD(0x16C, PIN_DISABLE, 7) /* (U28) disable P9_21b */
+            J721E_IOPAD(0x1E4, PIN_DISABLE, 7) /* (Y2) disable P9_18b */
+            /* No conflicting pad for P9_23 (AG20), so no disable needed */
+		>;
+	};
+};
+
+/*
+ * SPI6 controller configuration with support for two chip selects (CS0 and CS1).
+ */
+&main_spi6 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi6_pins>;
+    ti,spi-num-cs = <2>; /* Support two chip selects */
+    ti,pindir-d0-out-d1-in;
+    status = "okay";
+
+	/* THIS IS FOR SPIDEV, to see device at /dev/bone/spi, first run `sudo modprobe spidev` */
+	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+
+    /* Channel for SPI6_CS0 */
+    channel@0 {
+        symlink = "bone/spi/6.0";
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+
+    /* Channel for SPI6_CS1 */
+    channel@1 {
+        symlink = "bone/spi/6.1";
+        compatible = "rohm,dh2228fv";
+        reg = <1>;  /* CE1 */
+        spi-max-frequency = <125000000>;
+    };
+    
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
@@ -62,7 +62,7 @@
 			J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
 			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
 			J721E_IOPAD(0xa4, PIN_INPUT, 4) /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
-            /* J721E_IOPAD(0x28, PIN_OUTPUT, 4) */ /* (AG20) PRG1_PRU1_GPO8.SPI6_CS1 P9_23 */
+            J721E_IOPAD(0x28, PIN_OUTPUT, 4) /* (AG20) PRG1_PRU1_GPO8.SPI6_CS1 P9_23 */
 
             /* Disable SoC pins that share same BB header pins */
             /* These pins conflict */

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
@@ -11,6 +11,14 @@
  * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
  */
 
+/* 
+ *WARNING!!!
+ * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
+ * pins P9_17 and P9_18. To stop pin conflicts this overlay disables i2c6.
+ *
+ * Look for errors in `sudo beagle-version \| grep UBOOT`
+ */
+
 /dts-v1/;
 /plugin/;
 
@@ -25,6 +33,11 @@
         k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.kernel = __TIMESTAMP__;
         mcspi6.2160000.spi = "k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.2160000";
     };
+};
+
+/* Disable i2c6 to free up pins p9_17 and p9_18 */
+&main_i2c6 {
+        status = "disable";
 };
 
 /* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0-cs1.dtso
@@ -14,7 +14,7 @@
 /* 
  *WARNING!!!
  * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
- * pins P9_17 and P9_18. To stop pin conflicts this overlay disables i2c6.
+ * pins P9_17 and P9_18. To stop pin conflicts, this overlay disables i2c6.
  *
  * Look for errors in `sudo beagle-version \| grep UBOOT`
  */
@@ -44,27 +44,8 @@
  * in the following spreadsheet. To figure out mux modes, look at row 10.
  * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
  *
- * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
  * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
- *
- *
- * ~~ Walkthrough of process to figure out muxing ~~
- *
- * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
- * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
- * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
- * 
- * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
- * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
- * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
- * 
- * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
- * pad U29. Using the same process as walked through with pad AC22, you get the following:
- * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
- *
- * So to mux SPI6_CLK on BB pin P9_22:
- * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
- * J721E_IOPAD(0x170, PIN_DISABLE, 7)
  *
 */
 &main_pmx0 {
@@ -90,6 +71,12 @@
 
 /*
  * SPI6 controller configuration with support for two chip selects (CS0 and CS1).
+ *
+ *
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
  */
 &main_spi6 {
     #address-cells = <1>;
@@ -105,7 +92,7 @@
 
     /* Channel for SPI6_CS0 */
     channel@0 {
-        symlink = "bone/spi/6.0";
+        symlink = "bone/spi/6.0"; /* /dev/bone/spi/6.0 */
         compatible = "rohm,dh2228fv";
         reg = <0>; /* CE0 */
         spi-max-frequency = <125000000>;
@@ -113,7 +100,7 @@
 
     /* Channel for SPI6_CS1 */
     channel@1 {
-        symlink = "bone/spi/6.1";
+        symlink = "bone/spi/6.1"; /* /dev/bone/spi/6.1 */
         compatible = "rohm,dh2228fv";
         reg = <1>;  /* CE1 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for pins P9_28(cs0), P9_31(clk), P9_30(MOSI), P9_29B(MISO) SPI6 connections within the expansion header.
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi6-cs0.kernel = __TIMESTAMP__;
+                mcspi6.2160000.spi = "k3-j721e-beagleboneai64-spi-mcspi6-cs0.2160000";
+        };
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+
+ * ~~ Walkthrough of process to figure out muxing ~~
+ *
+ * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
+ * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
+ * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
+ * 
+ * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
+ * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
+ * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
+ * 
+ * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
+ * pad U29. Using the same process as walked through with pad AC22, you get the following:
+ * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
+ *
+ * So to mux SPI6_CLK on BB pin P9_22:
+ * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
+ * J721E_IOPAD(0x170, PIN_DISABLE, 7)
+ *
+*/
+&main_pmx0 {
+	mcspi6_cs_zero: mcspi6-cs0-pins {
+		pinctrl-single,pins = <
+			J721E_IOPAD(0x234, PIN_OUTPUT, 6) /* (U3) EXT_REFCLK1.SPI7_CLK P9_31a*/
+			J721E_IOPAD(0xD4, PIN_DISABLE, 7) /* (AB26) disable p9_31b */
+			J721E_IOPAD(0x230, PIN_OUTPUT, 6) /* (U2) ECAP0_IN_APWM_OUT.SPI7_CS0 P9_28a */
+			J721E_IOPAD(0xB0, PIN_DISABLE, 7) /* (AF28) disable p9_28b */
+			J721E_IOPAD(0x238, PIN_OUTPUT, 6) /* (V6) TIMER_IO0.SPI7_D0 MOSI P9_30a */
+			J721E_IOPAD(0xB4, PIN_DISABLE, 7) /* (AE28) disable P9_30b */
+			J721E_IOPAD(0x23c, PIN_INPUT, 6) /* (V5) TIMER_IO1.SPI7_D1 MISO P9_29a */
+			J721E_IOPAD(0xD8, PIN_DISABLE, 7) /* (AB25) disable p9_29b */
+
+            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+            J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
+			J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
+			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
+			J721E_IOPAD(0xa4, PIN_INPUT, 4) /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
+
+            /* Disable SoC pins that share same BB header pins */
+            /* This pin conflics*/
+            J721E_IOPAD(0x170, PIN_DISABLE, 7) /* (U29) disable P9_22b */
+            J721E_IOPAD(0x1D0, PIN_DISABLE, 7) /* (AA3) disable P9_17b */
+            J721E_IOPAD(0x16C, PIN_DISABLE, 7) /* (U28) disable P9_21b */
+            J721E_IOPAD(0x1E4, PIN_DISABLE, 7) /* (Y2) disable P9_18b */
+		>;
+	};
+};
+
+&main_spi6 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi6_cs_zero>;
+    ti,spi-num-cs = <1>;
+    ti,pindir-d0-out-d1-in;
+    status = "okay";
+
+	/* THIS IS FOR SPIDEV, to see device at /dev/bone/spi, first run `sudo modprobe spidev` */
+	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/6.0";
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
@@ -6,9 +6,10 @@
  *
  */
 
-/* WARNING!!!
+/* 
+ * WARNING!!!
  * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
- * pins P9_17 and P9_18.
+ * pins P9_17 and P9_18. To stop pin conflicts this overlay disables i2c6.
  *
  * Look for errors in `sudo beagle-version \| grep UBOOT`
  */
@@ -27,6 +28,11 @@
                 k3-j721e-beagleboneai64-spi-mcspi6-cs0.kernel = __TIMESTAMP__;
                 mcspi6.2160000.spi = "k3-j721e-beagleboneai64-spi-mcspi6-cs0.2160000";
         };
+};
+
+/* Disable i2c6 to free up pins p9_17 and p9_18 */
+&main_i2c6 {
+        status = "disable";
 };
 
 /* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-only OR MIT
 /*
- * DT Overlay for pins P9_28(cs0), P9_31(clk), P9_30(MOSI), P9_29B(MISO) SPI6 connections within the expansion header.
+ * DT Overlay for SPI6 pins P9_17(cs0), P9_22(clk), P9_21(MOSI), P9_18(MISO).
  *
  * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
  *
+ */
+
+/* WARNING!!!
+ * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
+ * pins P9_17 and P9_18.
+ *
+ * Look for errors in `sudo beagle-version \| grep UBOOT`
  */
 
 /dts-v1/;
@@ -68,6 +75,10 @@
 	};
 };
 
+/* Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ */
 &main_spi6 {
     #address-cells = <1>;
     #size-cells = <0>;
@@ -77,10 +88,9 @@
     ti,pindir-d0-out-d1-in;
     status = "okay";
 
-	/* THIS IS FOR SPIDEV, to see device at /dev/bone/spi, first run `sudo modprobe spidev` */
-	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@0 {
-        symlink = "bone/spi/6.0";
+        symlink = "bone/spi/6.0"; /* /dev/bone/spi/6.0 */
         compatible = "rohm,dh2228fv";
         reg = <0>; /* CE0 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
@@ -51,17 +51,7 @@
 */
 &main_pmx0 {
 	mcspi6_cs_zero: mcspi6-cs0-pins {
-		pinctrl-single,pins = <
-			J721E_IOPAD(0x234, PIN_OUTPUT, 6) /* (U3) EXT_REFCLK1.SPI7_CLK P9_31a*/
-			J721E_IOPAD(0xD4, PIN_DISABLE, 7) /* (AB26) disable p9_31b */
-			J721E_IOPAD(0x230, PIN_OUTPUT, 6) /* (U2) ECAP0_IN_APWM_OUT.SPI7_CS0 P9_28a */
-			J721E_IOPAD(0xB0, PIN_DISABLE, 7) /* (AF28) disable p9_28b */
-			J721E_IOPAD(0x238, PIN_OUTPUT, 6) /* (V6) TIMER_IO0.SPI7_D0 MOSI P9_30a */
-			J721E_IOPAD(0xB4, PIN_DISABLE, 7) /* (AE28) disable P9_30b */
-			J721E_IOPAD(0x23c, PIN_INPUT, 6) /* (V5) TIMER_IO1.SPI7_D1 MISO P9_29a */
-			J721E_IOPAD(0xD8, PIN_DISABLE, 7) /* (AB25) disable p9_29b */
-
-            
+		pinctrl-single,pins = <            
             /* Used TI SysConfig app to generate these, had manually adjust output modes */
             J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
 			J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs0.dtso
@@ -9,7 +9,7 @@
 /* 
  * WARNING!!!
  * This overlay will not mux if there are pin conflicts. For example, by default i2c6 is enabled taking
- * pins P9_17 and P9_18. To stop pin conflicts this overlay disables i2c6.
+ * pins P9_17 and P9_18. To stop pin conflicts, this overlay disables i2c6.
  *
  * Look for errors in `sudo beagle-version \| grep UBOOT`
  */
@@ -39,37 +39,18 @@
  * in the following spreadsheet. To figure out mux modes, look at row 10.
  * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
  *
- * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
  * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
- *
-
- * ~~ Walkthrough of process to figure out muxing ~~
- *
- * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
- * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
- * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
- * 
- * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
- * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
- * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
- * 
- * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
- * pad U29. Using the same process as walked through with pad AC22, you get the following:
- * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
- *
- * So to mux SPI6_CLK on BB pin P9_22:
- * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
- * J721E_IOPAD(0x170, PIN_DISABLE, 7)
  *
 */
 &main_pmx0 {
-	mcspi6_cs_zero: mcspi6-cs0-pins {
-		pinctrl-single,pins = <            
+    mcspi6_cs_zero: mcspi6-cs0-pins {
+        pinctrl-single,pins = <            
             /* Used TI SysConfig app to generate these, had manually adjust output modes */
             J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
-			J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
-			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
-			J721E_IOPAD(0xa4, PIN_INPUT, 4) /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
+            J721E_IOPAD(0x74, PIN_OUTPUT, 4) /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
+            J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
+            J721E_IOPAD(0xa4, PIN_INPUT, 4) /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
 
             /* Disable SoC pins that share same BB header pins */
             /* This pin conflics*/
@@ -77,13 +58,15 @@
             J721E_IOPAD(0x1D0, PIN_DISABLE, 7) /* (AA3) disable P9_17b */
             J721E_IOPAD(0x16C, PIN_DISABLE, 7) /* (U28) disable P9_21b */
             J721E_IOPAD(0x1E4, PIN_DISABLE, 7) /* (Y2) disable P9_18b */
-		>;
-	};
+        >;
+    };
 };
 
-/* Most of the stuff in this section is here for the spidev linux driver. For control from
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
  * from a DSP or R5 core, only the status and pinctrl parts matter.
  *
+ * Make sure to load the spidev driver to control SPI from linux.
  */
 &main_spi6 {
     #address-cells = <1>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
@@ -70,7 +70,7 @@
 	};
 };
 
-/* Most of the stuff in this section is only here for the spidev linux driver. For control from
+/* Most of the stuff in this section is here for the spidev linux driver. For control from
  * from a DSP or R5 core, only the status and pinctrl parts matter.
  *
  */

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
@@ -26,27 +26,8 @@
  * in the following spreadsheet. To figure out mux modes, look at row 10.
  * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
  *
- * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processor datasheet
  * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
- *
-
- * ~~ Walkthrough of process to figure out muxing ~~
- *
- * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
- * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
- * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
- * 
- * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
- * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
- * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
- * 
- * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
- * pad U29. Using the same process as walked through with pad AC22, you get the following:
- * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
- *
- * So to mux SPI6_CLK on BB pin P9_22:
- * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
- * J721E_IOPAD(0x170, PIN_DISABLE, 7)
  *
 */
 &main_pmx0 {
@@ -54,25 +35,23 @@
 		pinctrl-single,pins = <            
             /* Used TI SysConfig app to generate these, had manually adjust output modes */
             J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
-			/* J721E_IOPAD(0x74, PIN_OUTPUT, 4) */ /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
 			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
-			/* J721E_IOPAD(0xa4, PIN_INPUT, 4) */ /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
             J721E_IOPAD(0x28, PIN_OUTPUT, 4) /* (AG20) PRG1_PRU1_GPO8.SPI6_CS1 P9_23 */
 
             /* Disable SoC pins that share same BB header pins */
             /* This pin conflics*/
             J721E_IOPAD(0x170, PIN_DISABLE, 7) /* (U29) disable P9_22b */
-            /* J721E_IOPAD(0x1D0, PIN_DISABLE, 7) */ /* (AA3) disable P9_17b */
             J721E_IOPAD(0x16C, PIN_DISABLE, 7) /* (U28) disable P9_21b */
-            /* J721E_IOPAD(0x1E4, PIN_DISABLE, 7) */ /* (Y2) disable P9_18b */
             /* No conflicting pad for P9_23 (AG20), so no disable needed */
 		>;
 	};
 };
 
-/* Most of the stuff in this section is here for the spidev linux driver. For control from
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
  * from a DSP or R5 core, only the status and pinctrl parts matter.
  *
+ * Make sure to load the spidev driver to control SPI from linux.
  */
 &main_spi6 {
     #address-cells = <1>;
@@ -85,7 +64,7 @@
 
 	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@1 {
-        symlink = "bone/spi/6.1";
+        symlink = "bone/spi/6.1"; /* /dev/bone/spi/6.1 */
         compatible = "rohm,dh2228fv";
         reg = <1>; /* CE1 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
@@ -84,7 +84,7 @@
     status = "okay";
 
 	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
-    channel@0 {
+    channel@1 {
         symlink = "bone/spi/6.1";
         compatible = "rohm,dh2228fv";
         reg = <1>; /* CE1 */

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for SPI6 pins P9_23(cs1), P9_22(clk), P9_21(MOSI).
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi6-cs1.kernel = __TIMESTAMP__;
+                mcspi6.2160000.spi = "k3-j721e-beagleboneai64-spi-mcspi6-cs1.2160000";
+        };
+};
+
+/* To figure out which SoC pad numbers go with which BB header pins, look at columns A and B
+ * in the following spreadsheet. To figure out mux modes, look at row 10.
+ * https://drive.google.com/file/d/15NLaUeMBy-iT8s6rFrP4Esf0Qh57T4xu/view?pli=1
+ *
+ * To figure out the addresses of SoC pads, look at table "Table 5-125. Pin Multiplexing" in the TDA4VM Processors datasheet
+ * https://www.ti.com/lit/ds/symlink/tda4vm.pdf?ts=1741890214437&ref_url=https%253A%252F%252Fwww.ti.com%252Fproduct%252FTDA4VM
+ *
+
+ * ~~ Walkthrough of process to figure out muxing ~~
+ *
+ * From the spreadsheet we see that pad AC22 is the first pad on BB header pin P9_22. AC22 is thus known as P9_22a. The alternative
+ * pad, U29, is known as P9_22b. From Looking at the TDA4VM datasheet, we see that AC22(aka P9_22a) has the address 0x00011C09C. For 
+ * the J721E_IOPAD() pin-mux macro, we need the bottom 24bits of the address, so 0x09c, or 0x9c. 
+ * 
+ * To mux AC22(aka P9_22a) to be SPI6_CLK, as figured out from the spreadsheet, we need to set AC22 to mux-mode 4. And since
+ * a SPI clock is an output signal, the pin should be put set to PIN_OUTPUT mode.
+ * So `J721E_IOPAD(0x9c, PIN_OUTPUT, 4)`
+ * 
+ * We will also need to disable the second SoC pad that shares the same BB header pin. The SoC pad known as pin P9_22b, or 
+ * pad U29. Using the same process as walked through with pad AC22, you get the following:
+ * `J721E_IOPAD(0x170, PIN_DISABLE, 7)`
+ *
+ * So to mux SPI6_CLK on BB pin P9_22:
+ * J721E_IOPAD(0x9c, PIN_OUTPUT, 4)
+ * J721E_IOPAD(0x170, PIN_DISABLE, 7)
+ *
+*/
+&main_pmx0 {
+	mcspi6_cs_one: mcspi6-cs1-pins {
+		pinctrl-single,pins = <            
+            /* Used TI SysConfig app to generate these, had manually adjust output modes */
+            J721E_IOPAD(0x9c, PIN_OUTPUT, 4) /* (AC22) PRG1_PRU1_GPO17.SPI6_CLK P9_22a */
+			/* J721E_IOPAD(0x74, PIN_OUTPUT, 4) */ /* (AC21) PRG1_PRU1_GPO7.SPI6_CS0 P9_17a */
+			J721E_IOPAD(0xa0, PIN_OUTPUT, 4) /* (AJ22) PRG1_PRU1_GPO18.SPI6_D0 MOSI P9_21a */
+			/* J721E_IOPAD(0xa4, PIN_INPUT, 4) */ /* (AH22) PRG1_PRU1_GPO19.SPI6_D1 MISO P9_18a */
+            J721E_IOPAD(0x28, PIN_OUTPUT, 4) /* (AG20) PRG1_PRU1_GPO8.SPI6_CS1 P9_23 */
+
+            /* Disable SoC pins that share same BB header pins */
+            /* This pin conflics*/
+            J721E_IOPAD(0x170, PIN_DISABLE, 7) /* (U29) disable P9_22b */
+            /* J721E_IOPAD(0x1D0, PIN_DISABLE, 7) */ /* (AA3) disable P9_17b */
+            J721E_IOPAD(0x16C, PIN_DISABLE, 7) /* (U28) disable P9_21b */
+            /* J721E_IOPAD(0x1E4, PIN_DISABLE, 7) */ /* (Y2) disable P9_18b */
+            /* No conflicting pad for P9_23 (AG20), so no disable needed */
+		>;
+	};
+};
+
+/* Most of the stuff in this section is only here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ */
+&main_spi6 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi6_cs_one>;
+    ti,spi-num-cs = <2>; /* With this number wrong, no spi device would get created, error seen with `sudo journalctl -k` */
+    ti,pindir-d0-out-d1-in; /* d1 is not really an input, the pin is not muxed */
+    status = "okay";
+
+	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/6.1";
+        compatible = "rohm,dh2228fv";
+        reg = <1>; /* CE1 */
+        spi-max-frequency = <125000000>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi6-cs1-no-miso.dtso
@@ -64,7 +64,7 @@
 
 	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@1 {
-        symlink = "bone/spi/6.1"; /* /dev/bone/spi/6.1 */
+        symlink = "bone/spi/6.1_no_miso"; /* /dev/bone/spi/6.1_no_miso */
         compatible = "rohm,dh2228fv";
         reg = <1>; /* CE1 */
         spi-max-frequency = <125000000>;

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi7-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi7-cs0.dtso
@@ -37,6 +37,12 @@
 	};
 };
 
+/* 
+ * Most of the stuff in this section is here for the spidev linux driver. For control from
+ * from a DSP or R5 core, only the status and pinctrl parts matter.
+ *
+ * Make sure to load the spidev driver to control SPI from linux.
+ */
 &main_spi7 {
     #address-cells = <1>;
     #size-cells = <0>;
@@ -46,8 +52,7 @@
     ti,pindir-d0-out-d1-in;
     status = "okay";
 
-	/* THIS IS FOR SPIDEV, to see device at /dev/bone/spi, first run `sudo modprobe spidev` */
-	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    /* When controlling SPI from outside linux, you may want to delete this spidev stuff */
     channel@0 {
         symlink = "bone/spi/7.0";
         compatible = "rohm,dh2228fv";

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi7-cs0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-spi-mcspi7-cs0.dtso
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for pins P9_28(cs0), P9_31(clk), P9_30(MOSI), P9_29B(MISO) SPI7 connections within the expansion header.
+ *
+ * Copyright (C) 2023 Texas Instruments Incorporated - https://www.ti.com/
+ *
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+*/
+&{/chosen} {
+        overlays {
+                k3-j721e-beagleboneai64-spi-mcspi7-cs0.kernel = __TIMESTAMP__;
+                mcspi7.2170000.spi = "k3-j721e-beagleboneai64-spi-mcspi7-cs0.2170000";
+        };
+};
+
+&main_pmx0 {
+	mcspi7_cs_zero: mcspi7-cs0-pins {
+		pinctrl-single,pins = <
+			J721E_IOPAD(0x234, PIN_OUTPUT, 6) /* (U3) EXT_REFCLK1.SPI7_CLK P9_31a*/
+			J721E_IOPAD(0xD4, PIN_DISABLE, 7) /* (AB26) disable p9_31b */
+			J721E_IOPAD(0x230, PIN_OUTPUT, 6) /* (U2) ECAP0_IN_APWM_OUT.SPI7_CS0 P9_28a */
+			J721E_IOPAD(0xB0, PIN_DISABLE, 7) /* (AF28) disable p9_28b */
+			J721E_IOPAD(0x238, PIN_OUTPUT, 6) /* (V6) TIMER_IO0.SPI7_D0 MOSI P9_30a */
+			J721E_IOPAD(0xB4, PIN_DISABLE, 7) /* (AE28) disable P9_30b */
+			J721E_IOPAD(0x23c, PIN_INPUT, 6) /* (V5) TIMER_IO1.SPI7_D1 MISO P9_29a */
+			J721E_IOPAD(0xD8, PIN_DISABLE, 7) /* (AB25) disable p9_29b */
+		>;
+	};
+};
+
+&main_spi7 {
+    #address-cells = <1>;
+    #size-cells = <0>;
+    pinctrl-names = "default";
+    pinctrl-0 = <&mcspi7_cs_zero>;
+    ti,spi-num-cs = <1>;
+    ti,pindir-d0-out-d1-in;
+    status = "okay";
+
+	/* THIS IS FOR SPIDEV, to see device at /dev/bone/spi, first run `sudo modprobe spidev` */
+	/* When controlling SPI from outside linux, you may want to delete this spidev stuff */
+    channel@0 {
+        symlink = "bone/spi/7.0";
+        compatible = "rohm,dh2228fv";
+        reg = <0>; /* CE0 */
+        spi-max-frequency = <125000000>;
+    };
+};


### PR DESCRIPTION
An overlay for each usable SPI on the BBAI64. There are some extra CS options for MCSPI2, 3, and 6 not covered. I figure from here it should be pretty intuitive for someone new to overlays to figure what to do.