### PR TITLE
arm64: overlays: Add overlay to disable LEDs

### DIFF
--- a/src/arm64/overlays/k3-am62-pocketbeagle2-leds-off.dtso
+++ b/src/arm64/overlays/k3-am62-pocketbeagle2-leds-off.dtso
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/leds/common.h>
+
+&{/} {
+	leds {
+		led-1 {
+			function = LED_FUNCTION_INDICATOR;
+			default-state = "off";
+			linux,default-trigger = "none";
+		};
+
+		led-2 {
+			function = LED_FUNCTION_INDICATOR;
+			default-state = "off";
+			linux,default-trigger = "none";
+		};
+	};
+};


### PR DESCRIPTION
Disables the triggers in all LEDs. This is to avoid confusion while working with vsx-examples