### PR TITLE
arm64: overlays: k3-am62-pocketbeagle2-leds-off: Also disable led-3/4

### DIFF
--- a/src/arm64/overlays/k3-am62-pocketbeagle2-leds-off.dtso
+++ b/src/arm64/overlays/k3-am62-pocketbeagle2-leds-off.dtso
@@ -25,5 +25,17 @@
 			default-state = "off";
 			linux,default-trigger = "none";
 		};
+
+		led-3 {
+			function = LED_FUNCTION_INDICATOR;
+			default-state = "off";
+			linux,default-trigger = "none";
+		};
+
+		led-4 {
+			function = LED_FUNCTION_INDICATOR;
+			default-state = "off";
+			linux,default-trigger = "none";
+		};
 	};
 };


### PR DESCRIPTION
led-3 seems to have some kind of trigger enabled now. So set it to none manually. Do the same for led-4 so that it does not break in future.