### PR TITLE
riscv: dts: beaglev: add mikrobus nodes

### DIFF
--- a/src/riscv/thead/th1520-beaglev-ahead.dts
+++ b/src/riscv/thead/th1520-beaglev-ahead.dts
@@ -37,7 +37,7 @@
 
 	memory@0 {
 		device_type = "memory";
-		reg = <0x0  0x00000000  0x1 0x00000000>;
+		reg = <0x0 0x00000000 0x1 0x00000000>;
 	};
 
 	leds {
@@ -122,12 +122,25 @@
 	led_pins: led-0 {
 		led-pins {
 			pins = "AUDIO_PA8",  /* GPIO4_8 */
-			       "AUDIO_PA9",  /* GPIO4_9 */
-			       "AUDIO_PA10", /* GPIO4_10 */
-			       "AUDIO_PA11", /* GPIO4_11 */
-			       "AUDIO_PA12"; /* GPIO4_12 */
+				   "AUDIO_PA9",  /* GPIO4_9 */
+				   "AUDIO_PA10", /* GPIO4_10 */
+				   "AUDIO_PA11", /* GPIO4_11 */
+				   "AUDIO_PA12"; /* GPIO4_12 */
 			bias-disable;
 			drive-strength = <3>;
+			input-disable;
+			input-schmitt-disable;
+			slew-rate = <0>;
+		};
+	};
+
+	mikrobus_rst_pins: mikrobus-rst-0 {
+		rst-pins {
+			pins = "AUDIO_PA3"; /* GPIO4_3 */
+			function = "gpio";
+			bias-disable;
+			drive-strength = <3>;
+			output-high;
 			input-disable;
 			input-schmitt-disable;
 			slew-rate = <0>;
@@ -139,7 +152,7 @@
 	i2c2_pins: i2c2-0 {
 		i2c-pins {
 			pins = "I2C2_SDA",
-			       "I2C2_SCL";
+				   "I2C2_SCL";
 			function = "i2c";
 			bias-pull-up = <48000>;
 			drive-strength = <7>;
@@ -152,11 +165,11 @@
 	gmac0_pins: gmac0-0 {
 		tx-pins {
 			pins = "GMAC0_TX_CLK",
-			       "GMAC0_TXEN",
-			       "GMAC0_TXD0",
-			       "GMAC0_TXD1",
-			       "GMAC0_TXD2",
-			       "GMAC0_TXD3";
+				   "GMAC0_TXEN",
+				   "GMAC0_TXD0",
+				   "GMAC0_TXD1",
+				   "GMAC0_TXD2",
+				   "GMAC0_TXD3";
 			function = "gmac0";
 			bias-disable;
 			drive-strength = <25>;
@@ -167,11 +180,11 @@
 
 		rx-pins {
 			pins = "GMAC0_RX_CLK",
-			       "GMAC0_RXDV",
-			       "GMAC0_RXD0",
-			       "GMAC0_RXD1",
-			       "GMAC0_RXD2",
-			       "GMAC0_RXD3";
+				   "GMAC0_RXDV",
+				   "GMAC0_RXD0",
+				   "GMAC0_RXD1",
+				   "GMAC0_RXD2",
+				   "GMAC0_RXD3";
 			function = "gmac0";
 			bias-disable;
 			drive-strength = <1>;
@@ -216,6 +229,53 @@
 			drive-strength = <1>;
 			input-enable;
 			input-schmitt-enable;
+			slew-rate = <0>;
+		};
+	};
+
+	mikrobus_gpio_pins: mikrobus-gpio-0 {
+		pwm-pins {
+			pins = "QSPI0_SSN1"; /* PWM2 */
+			function = "gpio";
+			bias-disable;
+			drive-strength = <3>;
+			input-disable;
+			input-schmitt-disable;
+			slew-rate = <0>;
+		};
+
+		int-pins {
+			pins = "GPIO2_21";
+			function = "gpio";
+			bias-pull-up;
+			drive-strength = <1>;
+			input-enable;
+			input-schmitt-enable;
+			slew-rate = <0>;
+		};
+	};
+
+	mikrobus_spi_pins: spi0-0 {
+		spi-pins {
+			pins = "SPI_SCLK",
+				   "SPI_MISO",
+				   "SPI_MOSI";
+			function = "spi";
+			bias-disable;
+			drive-strength = <7>;
+			input-enable; /* For MISO */
+			input-schmitt-enable;
+			slew-rate = <0>;
+		};
+
+		cs-pins {
+			pins = "GPIO2_20"; /* CS pin */
+			function = "gpio";
+			bias-disable;
+			drive-strength = <7>;
+			output-high; /* CS is active low, so default high */
+			input-disable;
+			input-schmitt-disable;
 			slew-rate = <0>;
 		};
 	};
@@ -268,7 +328,7 @@
 	i2c0_pins: i2c0-0 {
 		i2c-pins {
 			pins = "I2C0_SDA",
-			       "I2C0_SCL";
+				   "I2C0_SCL";
 			function = "i2c";
 			bias-pull-up = <48000>;
 			drive-strength = <7>;
@@ -278,10 +338,10 @@
 		};
 	};
 
-	i2c4_pins: i2c4-0 {
+	mikrobus_i2c_pins: i2c4-0 {
 		i2c-pins {
 			pins = "GPIO0_19", /* I2C4_SDA */
-			       "GPIO0_18"; /* I2C4_SCL */
+				   "GPIO0_18"; /* I2C4_SCL */
 			function = "i2c";
 			bias-pull-up = <48000>;
 			drive-strength = <7>;
@@ -294,10 +354,32 @@
 	i2c5_pins: i2c5-0 {
 		i2c-pins {
 			pins = "QSPI1_D0_MOSI", /* I2C5_SDA */
-			       "QSPI1_CSN0";    /* I2C5_SCL */
+				   "QSPI1_CSN0";    /* I2C5_SCL */
 			function = "i2c";
 			bias-pull-up = <48000>;
 			drive-strength = <7>;
+			input-enable;
+			input-schmitt-enable;
+			slew-rate = <0>;
+		};
+	};
+
+	mikrobus_uart_pins: uart3-0 {
+		tx-pins {
+			pins = "CHIP_DBG_TXD"; /* UART3_TXD */
+			function = "uart";
+			bias-disable;
+			drive-strength = <3>;
+			input-disable;
+			input-schmitt-disable;
+			slew-rate = <0>;
+		};
+
+		rx-pins {
+			pins = "CHIP_DBG_RXD"; /* UART3_RXD */
+			function = "uart";
+			bias-pull-up;
+			drive-strength = <1>;
 			input-enable;
 			input-schmitt-enable;
 			slew-rate = <0>;
@@ -333,6 +415,12 @@
 	status = "okay";
 };
 
+&uart3 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mikrobus_uart_pins>;
+	status = "okay";
+};
+
 &i2c0 {
 	clock-frequency = <100000>;
 	pinctrl-names = "default";
@@ -355,7 +443,7 @@
 &i2c4 {
 	clock-frequency = <100000>;
 	pinctrl-names = "default";
-	pinctrl-0 = <&i2c4_pins>;
+	pinctrl-0 = <&mikrobus_i2c_pins>;
 	status = "okay";
 };
 
@@ -363,5 +451,11 @@
 	clock-frequency = <100000>;
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c5_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mikrobus_spi_pins>;
 	status = "okay";
 };


### PR DESCRIPTION
added the GPIO, I2C, SPI and UART specific nodes for the mikroBUS