### PR TITLE
arm64: overlays: k3-am6232-pocketbeagle2-techlab-cape: Fix PWM LED

### DIFF
--- a/src/arm64/overlays/k3-am6232-pocketbeagle2-techlab-cape.dtso
+++ b/src/arm64/overlays/k3-am6232-pocketbeagle2-techlab-cape.dtso
@@ -42,19 +42,22 @@
 		pinctrl-0 = <&P1_33_A17_pwm>;
 
         	multi-led {
+        		color = <LED_COLOR_ID_RGB>;
+			max-brightness = <255>;
+
 			led-red {
 				pwms = <&epwm2 1 255 0>;
 				color = <LED_COLOR_ID_RED>;
 			};
 
-        		led-blue {
-				pwms = <&epwm2 0 255 0>;
-				color = <LED_COLOR_ID_BLUE>;
-			};
-
         		led-green {
 				pwms = <&ecap2 0 255 0>;
 				color = <LED_COLOR_ID_GREEN>;
+			};
+
+        		led-blue {
+				pwms = <&epwm2 0 255 0>;
+				color = <LED_COLOR_ID_BLUE>;
 			};
 		};
 	};


### PR DESCRIPTION
- The required properties have changed after the kernel update. So fix the overlay.
- Also reorder LED colors to conform to RGB