### PR TITLE
k3-am62-pocketbeagle2-ardupilot-cape: Fix and updates

### DIFF
--- a/src/arm64/overlays/k3-am62-pocketbeagle2-ardupilot-cape.dtso
+++ b/src/arm64/overlays/k3-am62-pocketbeagle2-ardupilot-cape.dtso
@@ -4,7 +4,7 @@
  *
  * https://docs.beagleboard.io/latest/boards/capes/cape-interface-spec.html#i2c
  */
-
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/gpio/gpio.h>
 #include "ti/k3-pinctrl.h"
 
@@ -14,9 +14,14 @@
 /*
  * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
  */
-&{/chosen} {
-	overlays {
-		PB2-ARDUPILOT.kernel = __TIMESTAMP__;
+/ {
+	compatible = "beagle,am62-pocketbeagle2", "ti,am625";
+	model = "BeagleBoard.org PocketBeagle2";
+
+	chosen {
+		overlays {
+			PB2-ARDUPILOT.kernel = __TIMESTAMP__;
+		};
 	};
 };
 
@@ -24,11 +29,11 @@
 &main_pmx0 {
 	main_spi0_pins: main-spi0-pins {
 		pinctrl-single,pins = <
-			AM62X_IOPAD(0x01bc, PIN_INPUT_PULLUP, 0) /* P2.25 (A14) SPI0_CLK */
-			AM62X_IOPAD(0x01c0, PIN_INPUT_PULLUP, 0) /* P2.27v(B13) SPI0_D0 */
-			AM62X_IOPAD(0x01c4, PIN_OUTPUT_PULLUP, 0) /* P2.29 SPI0_D1 */
-			AM62X_IOPAD(0x01b4, PIN_OUTPUT_PULLUP, 0) /* P2.31 (A13) SPI0_CS0 */
-			AM62X_IOPAD(0x01B8, PIN_OUTPUT_PULLUP, 0) /* P2.36 (C13) SPI0_CS1 */
+			AM62X_IOPAD(0x01bc, PIN_OUTPUT, 0) /* P2.25 (A14) SPI0_CLK */
+			AM62X_IOPAD(0x01c0, PIN_INPUT, 0) /* P2.27v(B13) SPI0_D0 */
+			AM62X_IOPAD(0x01c4, PIN_OUTPUT, 0) /* P2.29 SPI0_D1 */
+			AM62X_IOPAD(0x01b4, PIN_OUTPUT, 0) /* P2.31 (A13) SPI0_CS0 */
+			AM62X_IOPAD(0x01B8, PIN_OUTPUT, 0) /* P2.36 (C13) SPI0_CS1 */
 		>;
 	};
 	main_can0_pins: main-can0-pins {
@@ -85,6 +90,19 @@
 		AM62X_IOPAD(0x0104, PIN_INPUT_PULLUP, 8) /* P2.17 - RCINPUT*/
 		>;
 	};
+
+	main_led_pins: main-led-pins {
+		pinctrl-single,pins = <
+		AM62X_IOPAD(0x0174, PIN_OUTPUT_PULLDOWN, 7) /* P2.10 - LED C*/
+		AM62X_IOPAD(0x00B8, PIN_OUTPUT_PULLDOWN, 7) /* P2.02 - LED A*/
+		AM62X_IOPAD(0x00BC, PIN_OUTPUT_PULLDOWN, 7) /* P2.04 - LED B*/
+		AM62X_IOPAD(0x01A0, PIN_OUTPUT_PULLDOWN, 7) /* P1.02 - RELAY 1*/
+		AM62X_IOPAD(0x01A8, PIN_OUTPUT_PULLDOWN, 7) /* P1.04 - RELAY 2*/
+		AM62X_IOPAD(0x0180, PIN_OUTPUT_PULLDOWN, 7) /* P1.34 - RELAY 3*/
+		AM62X_IOPAD(0x013C, PIN_OUTPUT_PULLDOWN, 7) /* P1.12 - RELAY 4*/
+		/* AM62X_IOPAD(0x0160, PIN_OUTPUT_PULLDOWN, 7) */ /* P2.01 - BUZZER*/
+		>;
+	};
 };
 
 &main_spi0 {
@@ -133,13 +151,16 @@
 };
 
 &wkup_i2c0 {
-    status = "disabled";
+    status = "okay";
 };
 
 &main_i2c1 {
     status = "disabled";
 };
 
+&main_uart0 {
+	status = "disabled";
+};
 
 &main_uart1 {
         pinctrl-names = "default";
@@ -174,14 +195,23 @@
 	pinctrl-0 = <&main_prus_pins>;
 	status = "okay";
 };
-&main_gpio0 {
-	/* pinctrl-names = "default"; */
-	/* pinctrl-0 = <&main_gpio_pins>; */
+&main_gpio0 { 
 	status = "okay";
 };
 &main_gpio1 {
 	status = "okay";
 };
+
+&main_uart0 {
+	status = "disabled";
+};
 &ecap0 {
 	status = "okay";
+};
+&cbass_main {
+    bela_extra_gpios {
+        compatible = "gpio-leds";
+        pinctrl-0 = <&main_led_pins>;
+        pinctrl-names = "default";
+    };
 };


### PR DESCRIPTION
This PR fix some gpios for leds, buzzer and relaypins and SPI pin directions and pull up and pull down.
Include fix in power management to shutdown using the power button - was disabled by a mistake.