### PR TITLE
arm64: overlays: Add MSPM0 SWD overlay

### DIFF
--- a/src/arm64/overlays/k3-am62-pocketbeagle2-mspm0swd.dtso
+++ b/src/arm64/overlays/k3-am62-pocketbeagle2-mspm0swd.dtso
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * Copyright (C) 2025 Ayush Singh, BeagleBoard.org Foundation
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include "../ti/k3-pinctrl.h"
+
+&mcu_gpio0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&mspm0_swdio_pins_gpio>;
+	status = "okay";
+};
+
+&main_gpio0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&P2_35_gpio>;
+	status = "okay";
+};

--- a/src/arm64/ti/k3-am62-pocketbeagle2-pinmux.dtsi
+++ b/src/arm64/ti/k3-am62-pocketbeagle2-pinmux.dtsi
@@ -565,6 +565,13 @@
 			AM62X_MCU_IOPAD(0x003C, PIN_INPUT, 7) /* (E5) MCU_MCAN1_TX.MCU_GPIO0_15 */
 		>;
 	};
+
+	mspm0_swdio_pins_gpio: mspm0-swdio-gpio-pins {
+		pinctrl-single,pins = <
+			AM62X_MCU_IOPAD(0x0010, PIN_INPUT_PULLDOWN, 7) /* (C9) MCU_SPI0_D1.MCU_GPIO0_4 */
+
+		>;
+	};
 };
 
 &main_gpio0 {
@@ -588,7 +595,7 @@
 			  "P2.02/AIN6", "P2.04", "P2.06",	/* 45-47 */
 			  "P2.08", "P2.20", "P1.20",	/* 48-50 */
 			  "P2.24", "P2.33", "P2.18",	/* 51-53 */
-			  "P2.35/AIN5", "P1.36(V20)", "P1.33(AA23)",	/* 54-56 */
+			  "P2.35/AIN5/MSPM0_SWCLK", "P1.36(V20)", "P1.33(AA23)",	/* 54-56 */
 			  "P2.32", "P2.30", "P1.31",	/* 57-59 */
 			  "P2.34", "P2.28", "P1.29",	/* 60-62 */
 			  "P2.22", "P2.17", "",	/* 63-65 */
@@ -624,7 +631,7 @@
 &mcu_gpio0 {
 	pinctrl-names = "default";
 	gpio-line-names = "", "", "",   /* 0-2 */
-			  "", "", "P2.05(B5)",   /* 3-5 */
+			  "", "MSPM0_SWDIO", "P2.05(B5)",   /* 3-5 */
 			  "P2.07(A5)", "", "",   /* 6-8 */
 			  "", "", "",   /* 9-11 */
 			  "", "P1.26(D6)", "P1.28(B3)",   /* 12-14 */


### PR DESCRIPTION
- Add overlay to allow GPIO bitbang SWD support for MSPM0L1105 using openocd