### PR TITLE
BBORG_COMMS-00A2: Add RS485 configuration for UART4

### DIFF
--- a/src/arm/overlays/BBORG_COMMS-00A2.dtso
+++ b/src/arm/overlays/BBORG_COMMS-00A2.dtso
@@ -6,12 +6,16 @@
  */
 
 /*
- *
+ * CAN1 usage:
  * sudo ip link set can0 type can bitrate 500000
  * sudo ifconfig can0 up
  *
  * candump can0
  * cansend can0 123#DEADBEEF
+ *
+ * RS485 (UART4) usage:
+ * Device: /dev/ttyS4
+ * RS485 mode is enabled at boot time with GPIO3_19 as RTS direction control
  */
 
 /dts-v1/;
@@ -44,4 +48,8 @@
 
 &bone_uart_4 {
 	status = "okay";
+	rs485-rts-delay = <0 0>;
+	rts-gpio = <&gpio3 19 GPIO_ACTIVE_HIGH>;
+	rs485-rts-active-high;
+	linux,rs485-enabled-at-boot-time;
 };


### PR DESCRIPTION
This PR adds RS485 configuration to the BBORG_COMMS-00A2 device tree overlay, addressing issue #32.

## Changes
- Enabled RS485 mode for UART4 with proper GPIO control
- Added RS485 RTS delay configuration (0, 0)
- Configured GPIO3_19 as RTS direction control pin
- Set RTS active high mode
- Enabled RS485 at boot time
- Updated documentation comments with RS485 usage instructions

## Configuration Details
The RS485 configuration enables half-duplex RS485 communication on UART4 (/dev/ttyS4) with automatic direction control via GPIO3_19. This follows the pattern discussed in the BeagleBoard forums and aligns with the commented configuration in the base device tree files.

## Testing
This configuration should be tested with RS485 hardware on the COMMS cape to verify:
- Proper RTS direction control during transmit/receive
- Communication stability at various baud rates
- Compatibility with existing CAN functionality

Fixes #32