### PR TITLE
arm64: dts: k3-j721e: Add BBAI64 CSI1 IMX219 camera overlay

### DIFF
--- a/src/arm64/overlays/BBAI64-CSI1-imx219.dts
+++ b/src/arm64/overlays/BBAI64-CSI1-imx219.dts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * DT Overlay for RPi Camera V2.1 (IMX219) on CSI1 connector
+ * of BeagleBone AI-64 board.
+ *
+ * Copyright (C) 2025 BeagleBoard.org Foundation
+ *
+ * Camera Schematics: https://datasheets.raspberrypi.com/camera/camera-v2-schematics.pdf
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+ */
+&{/chosen} {
+	overlays {
+		BBAI64-CSI1-imx219.kernel = __TIMESTAMP__;
+	};
+};
+
+&{/} {
+	clk_csi1_imx219_fixed: csi1-imx219-xclk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24000000>;
+	};
+};
+
+&main_gpio0 {
+	status = "okay";
+};
+
+&main_i2c6 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx219_1: sensor@10 {
+		compatible = "sony,imx219";
+		reg = <0x10>;
+
+		clocks = <&clk_csi1_imx219_fixed>;
+		clock-names = "xclk";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&csi1_gpio_pins_default>;
+
+		enable-gpios = <&main_gpio0 101 GPIO_ACTIVE_HIGH>;
+
+		port {
+			csi2_cam1: endpoint {
+				remote-endpoint = <&csi2rx1_in_sensor>;
+				link-frequencies = /bits/ 64 <456000000>;
+				clock-lanes = <0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&cdns_csi2rx1 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		csi1_port0: port@0 {
+			reg = <0>;
+			status = "okay";
+
+			csi2rx1_in_sensor: endpoint {
+				remote-endpoint = <&csi2_cam1>;
+				bus-type = <4>; /* CSI2 DPHY */
+				clock-lanes = <0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&ti_csi2rx1 {
+	status = "okay";
+};
+
+&dphy1 {
+	status = "okay";
+};


### PR DESCRIPTION
Addeddevice tree overlay for IMX219 camera on CSI1 interface of BeagleBone AI-64 board. Enables GPIO0_101 (pin V25) as camera enable signal as requested in issue #66.

-----> Changes
- Created `BBAI64-CSI1-imx219.dts` overlay
- Sony IMX219 camera sensor on main_i2c6 (I2C1)
- Fixed 24MHz clock for camera
- Enable GPIO using existing `csi1_gpio_pins_default` pinmux
- CSI2 RX bridge and DPHY1 configuration
- 2-lane MIPI CSI-2 interface at 456 MHz link frequency

# Testing Note
I don't have BeagleBone AI-64 hardware with IMX219 camera to test this configuration. The overlay follows the pattern from other camera overlays in the tree and uses the GPIO pin (V25/GPIO0_101) specified in the issue. Hardware testing by maintainers would be appreciated to confirm:
- GPIO enable signal polarity is correct (currently set to ACTIVE_HIGH)
- Camera detection and functionality

Fixes: #66