### PR TITLE
arm64: dts: k3-j721e: Add BBAI64 MCAN0 overlay

### DIFF
--- a/src/arm64/overlays/BBAI64-CAN0-00A0.dts
+++ b/src/arm64/overlays/BBAI64-CAN0-00A0.dts
@@ -10,9 +10,6 @@
 /dts-v1/;
 /plugin/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/interrupt-controller/irq.h>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
 #include "ti/k3-pinctrl.h"
 
 &{/chosen} {

--- a/src/arm64/overlays/BBAI64-CAN0-00A0.dts
+++ b/src/arm64/overlays/BBAI64-CAN0-00A0.dts
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
 /*
  * https://beagleboard.org/ai-64
  * Copyright (C) 2025 BeagleBoard.org Foundation

--- a/src/arm64/overlays/BBAI64-CAN0-00A0.dts
+++ b/src/arm64/overlays/BBAI64-CAN0-00A0.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * https://beagleboard.org/ai-64
+ * Copyright (C) 2025 BeagleBoard.org Foundation
+ *
+ * CAN overlay for BeagleBone AI-64
+ * Enables MCAN0 on pins mapped to I2C2 by default
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/pinctrl/k3.h>
+
+&{/chosen} {
+	overlays {
+		BBAI64-CAN0-00A0.kernel = __TIMESTAMP__;
+	};
+};
+
+&main_pmx0 {
+	main_mcan0_pins_default: main-mcan0-default-pins {
+		pinctrl-single,pins = <
+			J721E_IOPAD(0x208, PIN_INPUT, 0) /* (W5) MCAN0_RX */
+			J721E_IOPAD(0x20c, PIN_OUTPUT, 0) /* (W6) MCAN0_TX */
+		>;
+	};
+};
+
+&main_mcan0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&main_mcan0_pins_default>;
+};
+
+&main_i2c2 {
+	status = "disabled";
+};

--- a/src/arm64/overlays/BBAI64-CAN0-00A0.dts
+++ b/src/arm64/overlays/BBAI64-CAN0-00A0.dts
@@ -13,7 +13,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/interrupt-controller/arm-gic.h>
-#include <dt-bindings/pinctrl/k3.h>
+#include "ti/k3-pinctrl.h"
 
 &{/chosen} {
 	overlays {

--- a/src/arm64/overlays/BBAI64-CSI1-imx219.dts
+++ b/src/arm64/overlays/BBAI64-CSI1-imx219.dts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * DT Overlay for RPi Camera V2.1 (IMX219) on CSI1 connector
+ * of BeagleBone AI-64 board.
+ *
+ * Copyright (C) 2025 BeagleBoard.org Foundation
+ *
+ * Camera Schematics: https://datasheets.raspberrypi.com/camera/camera-v2-schematics.pdf
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+
+/*
+ * Helper to show loaded overlays under: /proc/device-tree/chosen/overlays/
+ */
+&{/chosen} {
+	overlays {
+		BBAI64-CSI1-imx219.kernel = __TIMESTAMP__;
+	};
+};
+
+&{/} {
+	clk_csi1_imx219_fixed: csi1-imx219-xclk {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency = <24000000>;
+	};
+};
+
+&main_gpio0 {
+	status = "okay";
+};
+
+&main_i2c6 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	imx219_1: sensor@10 {
+		compatible = "sony,imx219";
+		reg = <0x10>;
+
+		clocks = <&clk_csi1_imx219_fixed>;
+		clock-names = "xclk";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&csi1_gpio_pins_default>;
+
+		enable-gpios = <&main_gpio0 101 GPIO_ACTIVE_HIGH>;
+
+		port {
+			csi2_cam1: endpoint {
+				remote-endpoint = <&csi2rx1_in_sensor>;
+				link-frequencies = /bits/ 64 <456000000>;
+				clock-lanes = <0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&cdns_csi2rx1 {
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		csi1_port0: port@0 {
+			reg = <0>;
+			status = "okay";
+
+			csi2rx1_in_sensor: endpoint {
+				remote-endpoint = <&csi2_cam1>;
+				bus-type = <4>; /* CSI2 DPHY */
+				clock-lanes = <0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&ti_csi2rx1 {
+	status = "okay";
+};
+
+&dphy1 {
+	status = "okay";
+};


### PR DESCRIPTION
Add device tree overlay to enable MCAN0 (Controller Area Network) interface on BeagleBone AI-64 as requested in issue #65. The overlay configures main_mcan0 controller using pins W5 (MCAN0_RX) and W6 (MCAN0_TX).
# Changes
- Created `BBAI64-CAN0-00A0.dts` overlay
- Enables main_mcan0 CAN controller
- Pin configuration: W5 (0x208) for RX, W6 (0x20c) for TX
- Uses mux mode 0 for native MCAN0 functionality
# Important Note
This overlay disables I2C2 as both peripherals share the same physical pins. Users must choose between:
- CAN0 functionality (with this overlay)
- I2C2 functionality (default configuration)

The pins cannot be used simultaneously for both interfaces.
# Testing Note
I don't have BeagleBone AI-64 hardware with CAN transceiver to test this configuration. The overlay follows standard M_CAN controller configuration patterns used in other TI K3 devices. Hardware testing by maintainers or community members with CAN hardware would be appreciated.

Fixes: #65