### PR TITLE
Enable TPS65217 PMIC shutdown controller for BeagleBone Blue

### DIFF
--- a/src/arm/ti/omap/am335x-boneblue.dts
+++ b/src/arm/ti/omap/am335x-boneblue.dts
@@ -362,8 +362,6 @@
 /include/ "../../tps65217.dtsi"
 
 &tps {
-	/delete-property/ ti,pmic-shutdown-controller;
-
 	charger {
 		interrupts = <0>, <1>;
 		interrupt-names = "USB", "AC";


### PR DESCRIPTION

Fixes # ~68

# Problem
BeagleBone Blue does not shut down completely when using Debian 12.x with kernel 5.10.x or newer:
- 3V3 rail stays powered
- Power LED remains on  
- RED LED glimmers
- Requires pressing Reset button before it can boot again

This differs from Debian 10.3 behavior where shutdown worked correctly.

# Root Cause
The `am335x-boneblue.dts` file explicitly deletes the `ti,pmic-shutdown-controller` property from the TPS65217 PMIC configuration. This property is required for proper power sequencing during shutdown.

Without this property, the PMIC does not receive the shutdown signal to cut power to all voltage rails, leaving the board in a partially powered state.

# Solution
Remove the `/delete-property/ ti,pmic-shutdown-controller;` line to allow the PMIC shutdown controller to function. The property is defined in the inherited `tps65217.dtsi` and `am335x-bone-common.dtsi` files, and BBBlue should use it like other BeagleBone variants.

# Changes
- Removed `/delete-property/ ti,pmic-shutdown-controller;` from `&tps` node in `am335x-boneblue.dts`
- BBBlue now uses the standard PMIC shutdown sequence

# Expected Behavior After Fix
- System shutdown completes fully
- All LEDs turn off including power LED
- 3V3 rail powers down completely
- No manual reset required

# Testing Note
I don't have BeagleBone Blue hardware to test this configuration. The fix is based on:
- Issue reporter's description that Debian 10.3 worked (likely had this property enabled)
- Comparison with other BeagleBone variants that use `ti,pmic-shutdown-controller` successfully
- TPS65217 datasheet indicating shutdown controller is required for proper power-off

Hardware testing by maintainers or community members with BBBlue would be appreciated to confirm the fix resolves the shutdown issue.