### PR TITLE
scripts: rewrite-index.pl: fix filehandle usage and process cleanup

### DIFF
--- a/scripts/rewrite-index.pl
+++ b/scripts/rewrite-index.pl
@@ -2,26 +2,28 @@
 use strict;
 use warnings;
 use IPC::Open2;
-my $pid;
+my ($pid, $rderef, $wderef);
 
-open(my $lsfiles, "-|", "git ls-files -s") or die "fork lsfiles: $!";
-
+open(my $lsfiles, "-|", qw("git ls-files -s")) or die "fork lsfiles: $!";
+die "GIT_COMMIT not srt\n" unless defined $ENV{GIT_COMMIT};
 while (<$lsfiles>) {
     if ($_ =~ m/^120000 ([0-9a-f]{40}) (.*)\t(.*)/) {
-	my ($obj, $stage, $path) = ($1,$2,$3);
+	    my ($obj, $stage, $path) = ($1,$2,$3);
 	if (!defined $pid) {
-	    $pid = open2(*Rderef, *Wderef, "git cat-file --batch-check='deref-ok %(objectname)' --follow-symlinks")
+	    $pid = open2($Rderef, $Wderef, qw("git cat-file --batch-check='deref-ok %(objectname)' --follow-symlinks")
 		or die "open git cat-file: $!";
 	}
-	print Wderef "$ENV{GIT_COMMIT}:$path\n" or die "write Wderef: $!";
-	my $deref = <Rderef>;
-	if ($deref =~ m/^deref-ok ([0-9a-f]{40})$/) {
+	print {Wderef} "$ENV{GIT_COMMIT}:$path\n" or die "write Wderef: $!";
+	my $deref = <$rderef>;
+	if ($deref =~ /^deref-ok ([0-9a-f]{40})$/) {
 	    $_ = "100644 $1 $stage\t$path\n"
 	} elsif ($deref =~ /^dangling /) {
+	       scaler(<$rderef>);
 	    # Skip next line
-	    my $dummy = <Rderef>;
+		   next;
+
 	} else {
-	    die "Failed to parse symlink $ENV{GIT_COMMIT}:$path $deref";
+	    die "Failed to parse symlink $ENV{GIT_COMMIT}:$path ($deref");
 	}
     }
 
@@ -33,40 +35,42 @@ while (<$lsfiles>) {
     # A few architectures have dts files at non standard paths. Massage those into
     # a standard arch/ARCH/boot/dts first.
 
-    # symlink: arch/microblaze/boot/dts/system.dts -> ../../platform/generic/system.dts
-    next if m,\tarch/microblaze/boot/dts/system.dts$,;
-    $m++ if s,\tarch/microblaze/platform/generic/(system.dts)$,\tarch/microblaze/boot/dts/$1,;
+    # symlink: arch/microblaze/boot/dts\/system\.dts -> ../../platform/generic/system.dts
+    next if /\tarch\/microblaze/boot/dts/system\.dts$/;
+    $m++ if s,\tarch/microblaze/platform/generic/(system\.dts)$,\tarch/microblaze/boot/dts/$1,;
 
     # arch/mips/lantiq/dts/easy50712.dts
     # arch/mips/lantiq/dts/danube.dtsi
     # arch/mips/netlogic/dts/xlp_evp.dts
     # arch/mips/ralink/dts/rt3050.dtsi
     # arch/mips/ralink/dts/rt3052_eval.dts
-    $m++ if s,\tarch/mips/([^/]*)/dts/(.*\.dts.?)$,\tarch/mips/boot/dts/$2,;
+    $m++ if s,\tarch/mips/[^/]+/([^/]*\.dts.?)$,\tarch/mips/boot/dts/$1,;
 
     # arch/mips/cavium-octeon/octeon_68xx.dts
     # arch/mips/cavium-octeon/octeon_3xxx.dts
     # arch/mips/mti-sead3/sead3.dts
-    $m++ if s,\tarch/mips/([^/]*)/([^/]*\.dts.?)$,\tarch/mips/boot/dts/$2,;
+    $m++ if s,\tarch/mips/[^/]+/([^/]*\.dts.?)$,\tarch/mips/boot/dts/$1,;
 
     # arch/x86/platform/ce4100/falconfalls.dts
-    $m++ if s,\tarch/x86/platform/ce4100/falconfalls.dts,\tarch/x86/boot/dts/falconfalls.dts,;
+    $m++ if s,\tarch/x86/platform/ce4100/falconfalls\.dts$,\tarch/x86/boot/dts/falconfalls.dts,;
 
     # test cases
     $m++ if s,\tdrivers/of/testcase-data/,\ttestcase-data/,;
 
     # Now rewrite generic DTS paths
-    $m++ if s,\tarch/([^/]*)/boot/dts/(.*\.dts.?)$,\tsrc/$1/$2,;
+    $m++ if s,\tarch/([^/]+)/boot/dts/(.*\.dts.?)$,\tsrc/$1/$2,;
     $m++ if s,\tarch/([^/]*)/boot/dts/(.*\.h)$,\tsrc/$1/$2,;
 
     # Also rewrite the DTS include paths for dtc+cpp support
-    $m++ if s,\tarch/([^/]*)/include/dts/,\tsrc/$1/include/,;
-    $m++ if s,\tinclude/dt-bindings/,\tinclude/dt-bindings/,;
+    $m++ if s,\tarch/([^/]+)/include/dts/,\tsrc/$1/include/,;
 
     # Rewrite the bindings subdirectory
     $m++ if s,\tDocumentation/devicetree/bindings/,\tBindings/,;
 
-    print if $m > 0;
+    print if $m ;
 }
-kill $pid if $pid;
+close $lsfiles;
+close $wderef if defined $wderef;
+close $rderef if defined $rderef;
+waitpid($pid, 0) if defined $pid;
 exit 0;


### PR DESCRIPTION
Replace bareword filehandles with lexical filehandles in rewrite-index.pl. Add proper cleanup for the git cat-file child process and validate that GIT_COMMIT is set before use. No functional changes intended.