### PR TITLE
arm64: ti: k3-am625-beagleplay: Enable M4

### DIFF
--- a/src/arm64/ti/k3-am625-beagleplay.dts
+++ b/src/arm64/ti/k3-am625-beagleplay.dts
@@ -52,7 +52,7 @@
 		reg = <0x00000000 0x80000000 0x00000000 0x80000000>;
 	};
 
-	reserved-memory {
+	reserved_memory: reserved-memory {
 		#address-cells = <2>;
 		#size-cells = <2>;
 		ranges;
@@ -84,7 +84,13 @@
 			no-map;
 		};
 
-		wkup_r5fss0_core0_dma_memory_region: memory@9db00000 {
+		wkup_r5fss0_core0_dma_memory_region: memory@9da00000 {
+			compatible = "shared-dma-pool";
+			reg = <0x00 0x9da00000 0x00 0x100000>;
+			no-map;
+		};
+
+		wkup_r5fss0_core0_memory_region: memory@9db00000 {
 			compatible = "shared-dma-pool";
 			reg = <0x00 0x9db00000 0x00 0xc00000>;
 			no-map;
@@ -948,3 +954,5 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&mikrobus_pwm_pins_default>;
 };
+
+#include "k3-am62-ti-ipc-firmware.dtsi"


### PR DESCRIPTION
- Enable M4F core. Copied from PocketBeagle 2.