### PR TITLE
arm64: dts: Added overlays for bbai64

### DIFF
--- a/src/arm64/overlays/k3-j721e-beagleboneai64-ecap0.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-ecap0.dtso
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for ECAP0
+ * P9.28 - ECAP0_IN
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/soc/ti,sci_pm_domain.h>
+#include "ti/k3-pinctrl.h"
+
+&main_pmx0 {
+	ecap0_pins_default: ecap0-pins-default {
+		pinctrl-single,pins = <
+		J721E_IOPAD(0x230, PIN_INPUT, 0) /* P9_28 - ECAP0_IN */
+		>;
+	};
+};
+
+&cbass_main {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cap0: capture@3100000 {
+		compatible = "ti,am62-ecap-capture";
+		reg = <0x0 0x03100000 0x0 0x100>;
+		interrupt-parent = <&gic500>;
+		interrupts = <GIC_SPI 325 IRQ_TYPE_EDGE_RISING>;
+		power-domains = <&k3_pds 80 TI_SCI_PD_SHARED>;
+		clocks = <&k3_clks 80 0>;
+		clock-names = "fck";
+		pinctrl-names = "default";
+		pinctrl-0 = <&ecap0_pins_default>;
+		status = "okay";
+	};
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-ecap1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-ecap1.dtso
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for ECAP1
+ * P9.30 - ECAP1_IN
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/soc/ti,sci_pm_domain.h>
+#include "ti/k3-pinctrl.h"
+
+&main_pmx0 {
+	ecap1_pins_default: ecap1-pins-default {
+		pinctrl-single,pins = <
+		J721E_IOPAD(0x238, PIN_INPUT, 1) /* P9_30 - ECAP1_IN */
+		>;
+	};
+};
+
+&cbass_main {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cap1: capture@3110000 {
+		compatible = "ti,am62-ecap-capture";
+		reg = <0x0 0x03110000 0x0 0x100>;
+		interrupt-parent = <&gic500>;
+		interrupts = <GIC_SPI 326 IRQ_TYPE_EDGE_RISING>;
+		power-domains = <&k3_pds 81 TI_SCI_PD_SHARED>;
+		clocks = <&k3_clks 81 0>;
+		clock-names = "fck";
+		pinctrl-names = "default";
+		pinctrl-0 = <&ecap1_pins_default>;
+		status = "okay";
+	};
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-ecap2.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-ecap2.dtso
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for ECAP2
+ * P9.27 - ECAP2_IN
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/soc/ti,sci_pm_domain.h>
+#include "ti/k3-pinctrl.h"
+
+&main_pmx0 {
+	ecap2_pins_default: ecap2-pins-default {
+		pinctrl-single,pins = <
+		J721E_IOPAD(0x23c, PIN_INPUT, 1) /* P9_27 - ECAP2_IN */
+		>;
+	};
+};
+
+&cbass_main {
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	cap2: capture@3120000 {
+		compatible = "ti,am62-ecap-capture";
+		reg = <0x0 0x03120000 0x0 0x100>;
+		interrupt-parent = <&gic500>;
+		interrupts = <GIC_SPI 327 IRQ_TYPE_EDGE_RISING>;
+		power-domains = <&k3_pds 82 TI_SCI_PD_SHARED>;
+		clocks = <&k3_clks 82 0>;
+		clock-names = "fck";
+		pinctrl-names = "default";
+		pinctrl-0 = <&ecap2_pins_default>;
+		status = "okay";
+	};
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-eqep1.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-eqep1.dtso
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for EQEP1
+ * P8.35 - EQEP1_A
+ * P8.33 - EQEP1_B
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+#include <dt-bindings/soc/ti,sci_pm_domain.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+&{/chosen} {
+    overlays {
+        bbai64-eqep-only.kernel = __TIMESTAMP__;
+    };
+};
+
+&main_pmx0 {
+    eqep1_pins: eqep1-pins {
+        pinctrl-single,pins = <
+            J721E_IOPAD(0x64, PIN_INPUT, 9) /* P8_35 - EQEP1_A */
+            J721E_IOPAD(0x68, PIN_INPUT, 9) /* P8_33 - EQEP1_B */
+        >;
+    };
+};
+
+&cbass_main {
+    #address-cells = <2>;
+    #size-cells = <2>;
+
+    eqep1: qep@3210000 {
+        compatible = "ti,am3352-eqep";
+        reg = <0 0x3210000 0 0x100>;
+        power-domains = <&k3_pds 95 TI_SCI_PD_EXCLUSIVE>;
+        clocks = <&k3_clks 95 0>;
+        clock-names = "eqep1-ficlk";
+        interrupt-parent = <&gic500>;
+        interrupts = <GIC_SPI 323 IRQ_TYPE_EDGE_RISING>;
+        interrupt-names = "eqep1";
+        pinctrl-names = "default";
+        pinctrl-0 = <&eqep1_pins>;
+        status = "okay";
+
+        count_mode = <0>;
+        swap_input = <0>;
+        invert_qa = <0>;
+        invert_qb = <0>;
+    };
+};

--- a/src/arm64/overlays/k3-j721e-beagleboneai64-rs485-uart8.dtso
+++ b/src/arm64/overlays/k3-j721e-beagleboneai64-rs485-uart8.dtso
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-2.0-only OR MIT
+/*
+ * DT Overlay for RS485 support on UART8
+ * P8.28 - UART8_RXD
+ * P8.29 - UART8_TXD
+ * P8.20 - UART8_RTSn
+ */
+
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include "ti/k3-pinctrl.h"
+
+&{/chosen} {
+    overlays {
+        BONE-UART8-RS485.kernel = __TIMESTAMP__;
+    };
+};
+
+&main_pmx0 {
+    uart8_rs485_pins: uart8-rs485-pins {
+        pinctrl-single,pins = <
+            J721E_IOPAD(0x124, PIN_INPUT, 14)  /* P8_28 - UART8_RXD */
+            J721E_IOPAD(0x128, PIN_OUTPUT, 14) /* P8_29 - UART8_TXD */
+            J721E_IOPAD(0x134, PIN_OUTPUT, 14) /* P8_20 - UART8_RTSn */
+        >;
+    };
+};
+
+&main_uart8 {
+    pinctrl-names = "default";
+    pinctrl-0 = <&uart8_rs485_pins>;
+    symlink = "bone/uart/8";
+    status = "okay";
+
+    linux,rs485-enabled-at-boot-time;
+    rs485-rts-delay = <0 0>;
+
+    /* Use this line based on your hardware */
+    rs485-rts-active-low;
+};


### PR DESCRIPTION
Added the following overlays: ecap0, ecap1, ecap2, eqep1 and RS485 on UART8